### PR TITLE
Enable fuel level and fuel range sensors by default

### DIFF
--- a/custom_components/byd_vehicle/sensor.py
+++ b/custom_components/byd_vehicle/sensor.py
@@ -370,14 +370,14 @@ SENSOR_DESCRIPTIONS: tuple[BydSensorDescription, ...] = (
         source="realtime",
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
         icon="mdi:gas-station",
-        entity_registry_enabled_default=False,
+        entity_registry_enabled_default=True,
     ),
     BydSensorDescription(
         key="oil_percent",
         source="realtime",
         native_unit_of_measurement=PERCENTAGE,
         icon="mdi:gas-station",
-        entity_registry_enabled_default=False,
+        entity_registry_enabled_default=True,
     ),
     BydSensorDescription(
         key="total_oil",


### PR DESCRIPTION
## Summary
Enable PHEV fuel sensors by default so users can immediately see petrol tank status without manual entity enabling.

## Changes
- `oil_endurance` (`Fuel range`) now `entity_registry_enabled_default=True`
- `oil_percent` (`Fuel level`) now `entity_registry_enabled_default=True`

## Why
On PHEV vehicles (e.g. BYD SEAL U DM-i), these are core day-to-day sensors and are available in the official app. Keeping them disabled-by-default makes the integration appear to be missing fuel data.

## Validation
Tested on a live BYD SEAL U DM-i Home Assistant setup:
- `sensor.byd_seal_u_dm_i_fuel_level` now appears and reports value (e.g. `86%`)
- `sensor.byd_seal_u_dm_i_fuel_range` now appears and reports value (e.g. `436 km`)

No behavioral changes beyond default entity enablement.
