### PR TITLE
Document BYD charging state sensor semantics and caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,25 @@ Integration**, and search for **BYD Vehicle**.
 - A unique device fingerprint is generated per config entry to identify the
   integration to the BYD API.
 
+### Charging sensor semantics (field observations)
+
+BYD exposes multiple charging-related fields and their meaning is not yet fully
+documented by the upstream API. In practice:
+
+- `binary_sensor.<vin>_is_charging` is best treated as "actively charging now".
+- `sensor.<vin>_charge_state` can change even when active charging is `off`.
+- On at least one vehicle/region, `charge_state` was observed as:
+  - `15` while unplugged
+  - `-1` after charge-port/cable interaction (before active charging started)
+
+These integer values should currently be treated as **model/region-specific raw
+diagnostics**. If you automate against them, prefer combining them with:
+
+- `is_charging`
+- scheduled charging state
+- location/home state
+- explicit user notifications/fallbacks
+
 ### Debug dumps
 
 When **Debug dump API responses** is enabled in integration options, BYD API

--- a/custom_components/byd_vehicle/sensor.py
+++ b/custom_components/byd_vehicle/sensor.py
@@ -228,7 +228,9 @@ SENSOR_DESCRIPTIONS: tuple[BydSensorDescription, ...] = (
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    # Charging detail from realtime
+    # Charging detail from realtime.
+    # NOTE: charge_state/charging_state are currently surfaced as raw diagnostic
+    # values because API semantics appear to vary by model/region.
     BydSensorDescription(
         key="charging_state",
         source="realtime",


### PR DESCRIPTION
## Summary
- document observed semantics for charging-related sensors in README
- clarify that `charge_state`/`charging_state` are exposed as raw diagnostics
- add a small inline note in sensor definitions to make this explicit for maintainers

## Why
BYD cloud values for charging diagnostics are not fully documented and appear to vary by model/region. In real-world testing, `charge_state` changed even when active charging was off. This PR adds operational guidance so users can avoid brittle automations based on a single raw integer.

## Observations noted
- `is_charging` best represents active charging state
- `charge_state` can change while `is_charging` is off
- one observed mapping: `15` unplugged, `-1` after charge-port/cable interaction (before active charging)

## Scope
Docs/comment-only. No behavior change.
