### PR TITLE
feat: diagnostics, vehicle image, extended sensors, smart charging & push notifications

### DIFF
--- a/custom_components/byd_vehicle/const.py
+++ b/custom_components/byd_vehicle/const.py
@@ -12,6 +12,7 @@ PLATFORMS: list[Platform] = [
     Platform.BUTTON,
     Platform.CLIMATE,
     Platform.DEVICE_TRACKER,
+    Platform.IMAGE,
     Platform.LOCK,
     Platform.SELECT,
     Platform.SENSOR,

--- a/custom_components/byd_vehicle/diagnostics.py
+++ b/custom_components/byd_vehicle/diagnostics.py
@@ -1,0 +1,69 @@
+"""Diagnostics for BYD Vehicle integration."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+REDACT_KEYS = frozenset(
+    {
+        "username",
+        "password",
+        "control_pin",
+        "vin",
+        "device_profile",
+        "access_token",
+        "refresh_token",
+        "latitude",
+        "longitude",
+        "lat",
+        "lon",
+    }
+)
+
+
+def _redact(data: Any, depth: int = 0) -> Any:
+    """Recursively redact sensitive keys from nested structures."""
+    if depth > 10:
+        return "..."
+    if isinstance(data, dict):
+        return {
+            k: "**REDACTED**" if k in REDACT_KEYS else _redact(v, depth + 1)
+            for k, v in data.items()
+        }
+    if isinstance(data, list):
+        return [_redact(item, depth + 1) for item in data]
+    if dataclasses.is_dataclass(data) and not isinstance(data, type):
+        return _redact(dataclasses.asdict(data), depth + 1)
+    if hasattr(data, "__dict__"):
+        return _redact(
+            {k: v for k, v in data.__dict__.items() if not k.startswith("_")},
+            depth + 1,
+        )
+    return data
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+    coordinators = entry_data.get("coordinators", {})
+
+    coordinator_data = {}
+    for vin, coordinator in coordinators.items():
+        coordinator_data[vin] = _redact(coordinator.data)
+
+    return {
+        "entry": {
+            "data": _redact(dict(entry.data)),
+            "options": _redact(dict(entry.options)),
+        },
+        "coordinators": coordinator_data,
+    }

--- a/custom_components/byd_vehicle/image.py
+++ b/custom_components/byd_vehicle/image.py
@@ -1,0 +1,62 @@
+"""Vehicle image entity for BYD Vehicle."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from homeassistant.components.image import ImageEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import BydDataUpdateCoordinator, get_vehicle_display
+from .entity import BydVehicleEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up BYD vehicle image from a config entry."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinators: dict[str, BydDataUpdateCoordinator] = data["coordinators"]
+
+    entities: list[ImageEntity] = []
+    for vin, coordinator in coordinators.items():
+        vehicle = coordinator.data.get("vehicles", {}).get(vin)
+        if vehicle is None:
+            continue
+        url = getattr(vehicle, "pic_main_url", None)
+        if url:
+            entities.append(BydVehicleImage(coordinator, vin, vehicle, url))
+
+    async_add_entities(entities)
+
+
+class BydVehicleImage(BydVehicleEntity, ImageEntity):
+    """Representation of a BYD vehicle image."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "vehicle_image"
+    _attr_content_type = "image/png"
+
+    def __init__(
+        self,
+        coordinator: BydDataUpdateCoordinator,
+        vin: str,
+        vehicle: Any,
+        image_url: str,
+    ) -> None:
+        """Initialize the image entity."""
+        BydVehicleEntity.__init__(self, coordinator)
+        ImageEntity.__init__(self, coordinator.hass)
+        self._vin = vin
+        self._vehicle = vehicle
+        self._image_url = image_url
+        self._attr_unique_id = f"{vin}_vehicle_image"
+        self._attr_image_url = image_url
+        self._attr_image_last_updated = datetime.now()

--- a/custom_components/byd_vehicle/manifest.json
+++ b/custom_components/byd_vehicle/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pybyd>=0.0.49"
   ],
-  "version": "0.0.59"
+  "version": "0.0.60"
 }

--- a/custom_components/byd_vehicle/pybyd_ext.py
+++ b/custom_components/byd_vehicle/pybyd_ext.py
@@ -1,0 +1,177 @@
+"""Extension module for undocumented BYD API endpoints.
+
+Uses pybyd's internal transport layer to call endpoints not yet exposed
+by the library. This avoids forking pybyd while allowing access to
+smart charging, vehicle rename, and push notification controls.
+
+WARNING: Accesses private pybyd internals (_config, _session,
+_require_transport). May break with pybyd library updates.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from pybyd import BydApiError, BydClient
+from pybyd._api._envelope import build_token_outer_envelope
+from pybyd._crypto import aes_decrypt_utf8
+from pybyd._transport import SecureTransport
+from pybyd.config import BydConfig
+from pybyd.session import Session
+
+_LOGGER = logging.getLogger(__name__)
+
+# Undocumented endpoint paths
+_EP_CHARGE_TOGGLE = "/control/smartCharge/changeChargeStatue"
+_EP_CHARGE_SAVE = "/control/smartCharge/saveOrUpdate"
+_EP_VEHICLE_RENAME = "/control/vehicle/modifyAutoAlias"
+_EP_PUSH_GET = "/app/push/getPushSwitchState"
+_EP_PUSH_SET = "/app/push/setPushSwitchState"
+
+
+@dataclass(frozen=True)
+class SmartChargingConfig:
+    """Smart charging schedule configuration."""
+
+    target_soc: int = 80
+    start_hour: int = 0
+    start_minute: int = 0
+    end_hour: int = 6
+    end_minute: int = 0
+
+
+@dataclass(frozen=True)
+class PushNotificationState:
+    """Push notification toggle state."""
+
+    enabled: bool = True
+
+
+def _get_internals(
+    client: BydClient,
+) -> tuple[BydConfig, Session, SecureTransport]:
+    """Extract internal transport objects from a BydClient instance."""
+    config: BydConfig = client._config  # noqa: SLF001
+    session: Session = client._session  # noqa: SLF001
+    transport: SecureTransport = client._require_transport()  # noqa: SLF001
+    return config, session, transport
+
+
+def _build_inner(
+    config: BydConfig,
+    session: Session,
+    vin: str,
+    **extra: Any,
+) -> dict[str, Any]:
+    """Build the inner payload dict used by BYD API endpoints."""
+    payload: dict[str, Any] = {
+        "vin": vin,
+        "userId": session.user_id,
+        "countryCode": config.country_code,
+        "language": config.language,
+    }
+    payload.update(extra)
+    return payload
+
+
+async def _call_endpoint(
+    client: BydClient,
+    path: str,
+    vin: str,
+    **extra: Any,
+) -> dict[str, Any]:
+    """Call an undocumented BYD API endpoint and return the parsed response."""
+    config, session, transport = _get_internals(client)
+    inner = _build_inner(config, session, vin, **extra)
+    now_ms = int(time.time() * 1000)
+    envelope, content_key = build_token_outer_envelope(
+        config, session, inner, now_ms
+    )
+
+    raw = await transport.post_secure(path, envelope)
+
+    respond_data = raw.get("respondData")
+    if respond_data is None:
+        code = raw.get("code", raw.get("status", "unknown"))
+        msg = raw.get("msg", raw.get("message", ""))
+        raise BydApiError(f"API error {code}: {msg}")
+
+    decrypted = aes_decrypt_utf8(respond_data, content_key)
+    return json.loads(decrypted)
+
+
+async def toggle_smart_charging(
+    client: BydClient,
+    vin: str,
+    *,
+    enable: bool,
+) -> dict[str, Any]:
+    """Toggle smart charging on/off."""
+    return await _call_endpoint(
+        client,
+        _EP_CHARGE_TOGGLE,
+        vin,
+        smartChargeSwitch=1 if enable else 0,
+    )
+
+
+async def save_charging_schedule(
+    client: BydClient,
+    vin: str,
+    config: SmartChargingConfig,
+) -> dict[str, Any]:
+    """Save a smart charging schedule."""
+    return await _call_endpoint(
+        client,
+        _EP_CHARGE_SAVE,
+        vin,
+        targetSoc=config.target_soc,
+        startHour=config.start_hour,
+        startMinute=config.start_minute,
+        endHour=config.end_hour,
+        endMinute=config.end_minute,
+    )
+
+
+async def rename_vehicle(
+    client: BydClient,
+    vin: str,
+    *,
+    name: str,
+) -> dict[str, Any]:
+    """Rename a vehicle."""
+    return await _call_endpoint(
+        client,
+        _EP_VEHICLE_RENAME,
+        vin,
+        autoAlias=name,
+    )
+
+
+async def get_push_state(
+    client: BydClient,
+    vin: str,
+) -> PushNotificationState:
+    """Get push notification state."""
+    result = await _call_endpoint(client, _EP_PUSH_GET, vin)
+    enabled = bool(result.get("pushSwitch", 0))
+    return PushNotificationState(enabled=enabled)
+
+
+async def set_push_state(
+    client: BydClient,
+    vin: str,
+    *,
+    enable: bool,
+) -> dict[str, Any]:
+    """Set push notification state."""
+    return await _call_endpoint(
+        client,
+        _EP_PUSH_SET,
+        vin,
+        pushSwitch=1 if enable else 0,
+    )

--- a/custom_components/byd_vehicle/sensor.py
+++ b/custom_components/byd_vehicle/sensor.py
@@ -497,6 +497,205 @@ SENSOR_DESCRIPTIONS: tuple[BydSensorDescription, ...] = (
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    BydSensorDescription(
+        key="refrigerator_temp",
+        source="hvac",
+        icon="mdi:fridge-outline",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # ===========================================================
+    # HVAC: extended sensors (disabled by default)
+    # ===========================================================
+    BydSensorDescription(
+        key="air_conditioning_mode",
+        source="hvac",
+        icon="mdi:air-conditioner",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="air_run_state",
+        source="hvac",
+        icon="mdi:air-conditioner",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="copilot_setting_temp_new",
+        source="hvac",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="copilot_temp",
+        source="hvac",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="electric_defrost_status",
+        source="hvac",
+        icon="mdi:car-defrost-rear",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="front_defrost_status",
+        source="hvac",
+        icon="mdi:car-defrost-front",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="rapid_decrease_temp_state",
+        source="hvac",
+        icon="mdi:snowflake",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="rapid_increase_temp_state",
+        source="hvac",
+        icon="mdi:fire",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="wind_mode",
+        source="hvac",
+        icon="mdi:fan",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="wind_position",
+        source="hvac",
+        icon="mdi:weather-windy",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="wiper_heat_status",
+        source="hvac",
+        icon="mdi:car-windshield",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="pm25_state_out_car",
+        source="hvac",
+        icon="mdi:weather-hazy",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="cycle_choice",
+        source="hvac",
+        icon="mdi:rotate-3d-variant",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="air_temp_level",
+        source="hvac",
+        icon="mdi:thermometer-lines",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="air_condition_temp_range",
+        source="hvac",
+        icon="mdi:thermometer-auto",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # Third-row seat heating/ventilation (3-row vehicles only)
+    BydSensorDescription(
+        key="lr_third_heat_state",
+        source="hvac",
+        icon="mdi:car-seat-heater",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="rr_third_heat_state",
+        source="hvac",
+        icon="mdi:car-seat-heater",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="lr_third_ventilation_state",
+        source="hvac",
+        icon="mdi:car-seat-cooler",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="rr_third_ventilation_state",
+        source="hvac",
+        icon="mdi:car-seat-cooler",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # ===========================================================
+    # Realtime: extended vehicle metadata (disabled by default)
+    # ===========================================================
+    BydSensorDescription(
+        key="vehicle_state",
+        source="realtime",
+        icon="mdi:car-info",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="vehicle_state_info",
+        source="realtime",
+        icon="mdi:car-info",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="tire_press_unit",
+        source="realtime",
+        icon="mdi:car-tire-alert",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # Vehicle metadata (from vehicle object)
+    BydSensorDescription(
+        key="auto_plate",
+        source="vehicle",
+        icon="mdi:card-text",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="auto_bought_time",
+        source="vehicle",
+        icon="mdi:calendar",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="tbox_version",
+        source="vehicle",
+        icon="mdi:chip",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BydSensorDescription(
+        key="yun_active_time",
+        source="vehicle",
+        icon="mdi:cloud-check",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     # ==========================================
     # Last updated timestamp
     # ==========================================
@@ -594,7 +793,10 @@ class BydSensor(BydVehicleEntity, SensorEntity):
 
     def _get_source_obj(self, source: str = "") -> Any | None:
         """Return the model object for this sensor's source."""
-        return super()._get_source_obj(source or self.entity_description.source)
+        resolved = source or self.entity_description.source
+        if resolved == "vehicle":
+            return self.coordinator.data.get("vehicles", {}).get(self._vin)
+        return super()._get_source_obj(resolved)
 
     def _resolve_value(self) -> Any:
         """Extract the current value using the description's extraction logic."""

--- a/custom_components/byd_vehicle/services.yaml
+++ b/custom_components/byd_vehicle/services.yaml
@@ -21,3 +21,55 @@ fetch_hvac:
       selector:
         device:
           integration: byd_vehicle
+
+set_charging_schedule:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: byd_vehicle
+    target_soc:
+      required: true
+      selector:
+        number:
+          min: 20
+          max: 100
+          step: 5
+          unit_of_measurement: "%"
+    start_hour:
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 23
+    start_minute:
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 59
+    end_hour:
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 23
+    end_minute:
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 59
+
+rename_vehicle:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: byd_vehicle
+    name:
+      required: true
+      selector:
+        text:

--- a/custom_components/byd_vehicle/strings.json
+++ b/custom_components/byd_vehicle/strings.json
@@ -29,6 +29,50 @@
           "description": "The BYD vehicle device to fetch data for."
         }
       }
+    },
+    "set_charging_schedule": {
+      "name": "Set charging schedule",
+      "description": "Configure the smart charging schedule (target SOC and time window).",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The BYD vehicle device to configure."
+        },
+        "target_soc": {
+          "name": "Target SOC",
+          "description": "Target state of charge (%)."
+        },
+        "start_hour": {
+          "name": "Start hour",
+          "description": "Charging window start hour (0-23)."
+        },
+        "start_minute": {
+          "name": "Start minute",
+          "description": "Charging window start minute (0-59)."
+        },
+        "end_hour": {
+          "name": "End hour",
+          "description": "Charging window end hour (0-23)."
+        },
+        "end_minute": {
+          "name": "End minute",
+          "description": "Charging window end minute (0-59)."
+        }
+      }
+    },
+    "rename_vehicle": {
+      "name": "Rename vehicle",
+      "description": "Change the vehicle alias in the BYD cloud.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The BYD vehicle device to rename."
+        },
+        "name": {
+          "name": "Vehicle name",
+          "description": "New name for the vehicle (1-32 characters)."
+        }
+      }
     }
   },
   "config": {
@@ -135,6 +179,33 @@
       "upgrade_status": { "name": "OTA upgrade status" },
       "refrigerator_state": { "name": "Refrigerator" },
       "refrigerator_door_state": { "name": "Refrigerator door" },
+      "refrigerator_temp": { "name": "Refrigerator temperature" },
+      "air_conditioning_mode": { "name": "AC mode" },
+      "air_run_state": { "name": "AC run state" },
+      "copilot_setting_temp_new": { "name": "Passenger set temperature" },
+      "copilot_temp": { "name": "Passenger zone temperature" },
+      "electric_defrost_status": { "name": "Electric defrost" },
+      "front_defrost_status": { "name": "Front defrost" },
+      "rapid_decrease_temp_state": { "name": "Rapid cool" },
+      "rapid_increase_temp_state": { "name": "Rapid heat" },
+      "wind_mode": { "name": "Fan mode" },
+      "wind_position": { "name": "Airflow direction" },
+      "wiper_heat_status": { "name": "Wiper heating" },
+      "pm25_state_out_car": { "name": "Outdoor air quality" },
+      "cycle_choice": { "name": "Recirculation mode" },
+      "air_temp_level": { "name": "Air temperature level" },
+      "air_condition_temp_range": { "name": "A/C temperature range" },
+      "lr_third_heat_state": { "name": "Left rear third row heat" },
+      "rr_third_heat_state": { "name": "Right rear third row heat" },
+      "lr_third_ventilation_state": { "name": "Left rear third row ventilation" },
+      "rr_third_ventilation_state": { "name": "Right rear third row ventilation" },
+      "vehicle_state": { "name": "Vehicle state" },
+      "vehicle_state_info": { "name": "Vehicle state info" },
+      "tire_press_unit": { "name": "Tire pressure unit" },
+      "auto_plate": { "name": "License plate" },
+      "auto_bought_time": { "name": "Purchase date" },
+      "tbox_version": { "name": "T-Box version" },
+      "yun_active_time": { "name": "Cloud activation time" },
       "last_updated": { "name": "Telemetry last updated" },
       "gps_last_updated": { "name": "GPS last updated" }
     },
@@ -243,7 +314,12 @@
       "battery_heat": { "name": "Battery heat" },
       "car_on": { "name": "A/C on" },
       "steering_wheel_heat": { "name": "Steering wheel heating" },
-      "disable_polling": { "name": "Disable polling" }
+      "disable_polling": { "name": "Disable polling" },
+      "smart_charging": { "name": "Smart charging" },
+      "push_notifications": { "name": "Push notifications" }
+    },
+    "image": {
+      "vehicle_image": { "name": "Vehicle image" }
     },
     "climate": {
       "climate": {


### PR DESCRIPTION
## Summary

Implements the features proposed in #29, rebased cleanly onto current `main` (v0.0.59):

- **Diagnostics** — `async_get_config_entry_diagnostics()` with recursive redaction of sensitive keys (VIN, tokens, credentials, location)
- **Vehicle image entity** — exposes `pic_main_url` from the vehicle model as an HA `ImageEntity`
- **~27 new sensors** — HVAC details (fan mode, defrost, recirculation, air quality, refrigerator), vehicle metadata (plate, purchase date, T-Box version), tire pressure unit, 3rd-row seat heat/ventilation. All disabled by default with `entity_category=DIAGNOSTIC`
- **Smart charging switch + schedule service** — toggle smart charging on/off; `set_charging_schedule` service to configure target SOC and time window
- **Push notification switch** — toggle BYD cloud push notifications
- **Rename vehicle service** — change the vehicle alias in the BYD cloud

All entities follow the upstream `BydVehicleEntity` mixin pattern with `translation_key` and `_execute_command()`.

## Dependency

Requires [pyBYD PR #18](https://github.com/jkaberg/pyBYD/pull/18) to be merged first — it adds 7 fields to `HvacStatus` that the new sensors reference (`lr_third_heat_state`, `rr_third_heat_state`, `lr_third_ventilation_state`, `rr_third_ventilation_state`, `refrigerator_temp`, `air_temp_level`, `air_condition_temp_range`). Without that PR, those sensors will gracefully return `unavailable` via `getattr()` fallback.

## Files changed

| File | Action | Notes |
|------|--------|-------|
| `pybyd_ext.py` | NEW | Smart charging / push / rename via undocumented BYD API |
| `diagnostics.py` | NEW | Config entry diagnostics with redaction |
| `image.py` | NEW | Vehicle image entity |
| `const.py` | EDIT | Add `Platform.IMAGE` to PLATFORMS |
| `sensor.py` | EDIT | Add ~27 new sensor descriptions |
| `switch.py` | EDIT | Add smart charging + push notification switches |
| `services.yaml` | EDIT | Add `set_charging_schedule` + `rename_vehicle` |
| `__init__.py` | EDIT | Register new service handlers |
| `strings.json` | EDIT | Translation keys for all new entities + services |
| `manifest.json` | EDIT | Version bump to 0.0.60 |

## Test plan

- [ ] Verify all new sensors appear (disabled) in the entity registry
- [ ] Toggle smart charging switch and confirm state round-trips
- [ ] Call `set_charging_schedule` service and verify schedule saved
- [ ] Call `rename_vehicle` service and verify alias updated
- [ ] Check diagnostics download redacts sensitive keys
- [ ] Verify vehicle image loads from `pic_main_url`
- [ ] Confirm no regressions on existing entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)