### PR TITLE
Parse numeric strings with unit suffixes

### DIFF
--- a/custom_components/byd_vehicle/sensor.py
+++ b/custom_components/byd_vehicle/sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -85,11 +86,17 @@ def _round_int_attr(attr: str) -> Callable[[Any], int | None]:
     return _convert
 
 
+_LEADING_NUMBER_RE = re.compile(r"^\s*(-?\d+(?:\.\d+)?)")
+
+
 def _parse_numeric_string(attr: str) -> Callable[[Any], float | None]:
     """Create a converter that parses a string attribute to float.
 
     Returns *None* for sentinel strings like ``"--"`` or non-numeric values.
-    The BYD API sends several energy-related fields as strings (e.g. ``"29.6"``).
+    The BYD API sends several energy-related fields as strings. Some are
+    bare numbers (e.g. ``"29.6"``) while others include unit suffixes
+    (e.g. ``"18.4kW·h/100km"``, ``"11.9度/百公里"``). The fallback regex
+    extracts the leading numeric portion so both styles parse cleanly.
     """
 
     def _convert(obj: Any) -> float | None:
@@ -99,6 +106,13 @@ def _parse_numeric_string(attr: str) -> Callable[[Any], float | None]:
         try:
             return float(value)
         except (ValueError, TypeError):
+            if isinstance(value, str):
+                match = _LEADING_NUMBER_RE.match(value)
+                if match:
+                    try:
+                        return float(match.group(1))
+                    except ValueError:
+                        pass
             return None
 
     return _convert


### PR DESCRIPTION
Addresses #104.

## Root cause

`_parse_numeric_string` calls `float(value)` and returns `None` on `ValueError`. This works for bare numeric strings like `"18.4"` but fails for energy fields that include unit suffixes:

- `"18.4kW·h/100km"`
- `"11.9度/百公里"` (Chinese locale)
- `"11.9kW·h/100km"`

The underlying realtime data is correct — pyBYD parses and stores these fields with their full string values — but the HA sensor layer drops them to Unknown because the converter can't extract the numeric portion.

## Affected sensors

| Sensor | Realtime field | Example value | Currently |
|--------|----------------|---------------|-----------|
| `recent_50km_energy` | `recent_50km_energy` | `"18.4kW·h/100km"` | Unknown |
| `total_energy` | `total_energy` | `"11.9kW·h/100km"` | Unknown |
| `total_consumption` | `total_consumption` | `"11.9度/百公里"` | Unknown |
| `total_consumption_en` | `total_consumption_en` | `"11.9kW·h/100km"` | Unknown |

By contrast, `energy_consumption` and `nearest_energy_consumption` already work because BYD sends those as bare `"18.4"` strings (no unit suffix), so the existing `float()` call succeeds.

## Fix

Adds a regex fallback in `_parse_numeric_string`. The primary `float(value)` path is unchanged — bare numbers parse exactly as before. When `float()` raises `ValueError`, the fallback extracts the leading number from strings like `"18.4kW·h/100km"` → `18.4`.

## Tests

Verified locally with these inputs:

| Input | Result |
|-------|--------|
| `"18.4"` | `18.4` |
| `"18.4kW·h/100km"` | `18.4` |
| `"11.9度/百公里"` | `11.9` |
| `"--"` | `None` |
| `None` | `None` |
| `""` | `None` |
| `"  11.9kW·h/100km"` (leading space) | `11.9` |
| `"-5.2"` | `-5.2` |
| `"100"` (integer) | `100.0` |
| `"abc"` (garbage) | `None` |

No regressions on existing inputs. All previously-working sensors continue to work the same way.

## Companion fix in pyBYD

Related: jkaberg/pyBYD#27 — that PR adds a per-field filter to pyBYD so the four affected fields don't get clobbered by HTTP polls returning `"--"` between MQTT pushes.

Both fixes are needed for the full end-to-end resolution of #104:

- Without this parser fix, even MQTT-pushed values render as Unknown because the sensor converter rejects unit suffixes.
- Without the pyBYD filter, MQTT-pushed values get overwritten by HTTP `"--"` within seconds, so the sensor flickers between a brief value and Unknown.

This PR is independently useful (it fixes the parser bug) and the pyBYD fix is independently useful (it stops the clobber). Together they resolve the user-visible problem completely.

Verified end-to-end against a BYD Sealion 6 (Australia region) running both fixes locally — all four sensors populate from MQTT and remain stable across HTTP polls.
