### PR TITLE
add start_charging button + service

### DIFF
--- a/custom_components/byd_vehicle/__init__.py
+++ b/custom_components/byd_vehicle/__init__.py
@@ -326,6 +326,7 @@ _SERVICE_FETCH_GPS = "fetch_gps"
 _SERVICE_FETCH_HVAC = "fetch_hvac"
 _SERVICE_FETCH_CHARGING = "fetch_charging"
 _SERVICE_FETCH_ENERGY = "fetch_energy"
+_SERVICE_START_CHARGING = "start_charging"
 
 _ALL_SERVICES = (
     _SERVICE_FETCH_REALTIME,
@@ -333,6 +334,7 @@ _ALL_SERVICES = (
     _SERVICE_FETCH_HVAC,
     _SERVICE_FETCH_CHARGING,
     _SERVICE_FETCH_ENERGY,
+    _SERVICE_START_CHARGING,
 )
 
 
@@ -416,6 +418,11 @@ def _async_register_services(hass: HomeAssistant) -> None:
             coordinator, _ = _get_coordinators(hass, entry_id, vin)
             await coordinator.async_fetch_energy()
 
+    async def _handle_start_charging(call: ServiceCall) -> None:
+        for entry_id, vin in _resolve_vins_from_call(hass, call):
+            coordinator, _ = _get_coordinators(hass, entry_id, vin)
+            await coordinator.async_start_charging()
+
     hass.services.async_register(
         DOMAIN, _SERVICE_FETCH_REALTIME, _handle_fetch_realtime
     )
@@ -425,6 +432,9 @@ def _async_register_services(hass: HomeAssistant) -> None:
         DOMAIN, _SERVICE_FETCH_CHARGING, _handle_fetch_charging
     )
     hass.services.async_register(DOMAIN, _SERVICE_FETCH_ENERGY, _handle_fetch_energy)
+    hass.services.async_register(
+        DOMAIN, _SERVICE_START_CHARGING, _handle_start_charging
+    )
 
     _LOGGER.debug("Registered %s domain services", len(_ALL_SERVICES))
 

--- a/custom_components/byd_vehicle/button.py
+++ b/custom_components/byd_vehicle/button.py
@@ -68,6 +68,7 @@ async def async_setup_entry(
         gps_coordinator = gps_coordinators.get(vin)
 
         entities.append(BydForcePollButton(coordinator, gps_coordinator, vin, vehicle))
+        entities.append(BydStartChargingButton(coordinator, vin, vehicle))
         for description in BUTTON_DESCRIPTIONS:
             if not coordinator.capability_available(description.capability_key):
                 continue
@@ -138,3 +139,58 @@ class BydForcePollButton(BydVehicleEntity, ButtonEntity):
                 await gps.async_force_refresh()
         except Exception as exc:  # noqa: BLE001
             raise HomeAssistantError(str(exc)) from exc
+
+
+class BydStartChargingButton(BydVehicleEntity, ButtonEntity):
+    """Button that starts charging immediately."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "start_charging"
+    _attr_icon = "mdi:play"
+
+    def __init__(
+        self,
+        coordinator: BydDataUpdateCoordinator,
+        vin: str,
+        vehicle: Vehicle,
+    ) -> None:
+        super().__init__(coordinator)
+        self._vin = vin
+        self._vehicle = vehicle
+        self._attr_unique_id = f"{vin}_button_start_charging"
+
+    @property
+    def available(self) -> bool:
+        # BYD's cloud rejects /control/smartCharge/changeChargeStatue with
+        # res=3 "Operation failure" when the vehicle is already in the
+        # target state — either already charging, or at 100 % SoC with
+        # nothing to charge (see references/changeResult.md). Hide the
+        # button in those cases so users don't get a confusing error.
+        #
+        # Prefer realtime fields (always present, drive the user-visible
+        # battery_level / charging sensors) over the charging snapshot
+        # (only refreshed on smart-charging-page polls and may be None
+        # between updates).
+        if not super().available:
+            return False
+        snapshot = self._snapshot()
+        if snapshot is None:
+            return True
+        is_charging: bool | None = None
+        if snapshot.realtime is not None:
+            is_charging = snapshot.realtime.is_charging
+        if is_charging is None and snapshot.charging is not None:
+            is_charging = snapshot.charging.is_charging
+        if is_charging:
+            return False
+        soc: float | None = None
+        if snapshot.realtime is not None:
+            soc = snapshot.realtime.elec_percent
+        if soc is None and snapshot.charging is not None:
+            soc = snapshot.charging.soc
+        if soc is not None and soc >= 100:
+            return False
+        return True
+
+    async def async_press(self) -> None:
+        await self.coordinator.async_start_charging()

--- a/custom_components/byd_vehicle/coordinator.py
+++ b/custom_components/byd_vehicle/coordinator.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
@@ -26,6 +26,7 @@ from pybyd import (
     BydDataUnavailableError,
     BydEndpointNotSupportedError,
     BydRateLimitError,
+    BydRemoteControlError,
     BydSessionExpiredError,
     BydTransportError,
     CommandAckEvent,
@@ -813,6 +814,45 @@ class BydDataUpdateCoordinator(DataUpdateCoordinator[VehicleSnapshot]):
                 "Service fetch_energy failed: vin=%s, error=%s",
                 self._vin,
                 exc,
+            )
+
+    async def async_start_charging(self) -> None:
+        """Start charging immediately and refresh charging state on success.
+
+        Raises :class:`HomeAssistantError` on failure (auth, transport,
+        unsupported endpoint, polling timeout) so service callers see a
+        loud failure rather than a silent no-op.
+        """
+        if self._car is None:
+            raise HomeAssistantError(
+                f"BYD vehicle {self._vin[-6:]} not ready for charging commands"
+            )
+        try:
+            result = await self._car.start_charging()
+        except BydEndpointNotSupportedError as exc:
+            raise HomeAssistantError(
+                "start_charging not supported for this vehicle/region"
+            ) from exc
+        except BydRemoteControlError as exc:
+            raise HomeAssistantError(f"start_charging failed to settle: {exc}") from exc
+        except BydAuthenticationError as exc:
+            raise HomeAssistantError(f"start_charging failed (auth): {exc}") from exc
+        except (BydApiError, BydTransportError) as exc:
+            raise HomeAssistantError(f"start_charging failed: {exc}") from exc
+
+        _LOGGER.info(
+            "start_charging settled: vin=%s, message=%s",
+            self._vin[-6:],
+            result.message,
+        )
+
+        try:
+            await self._car.update_charging()
+            await self.async_request_refresh()
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "Post-start_charging refresh failed (non-fatal)",
+                exc_info=True,
             )
 
 

--- a/custom_components/byd_vehicle/manifest.json
+++ b/custom_components/byd_vehicle/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jkaberg/hass-byd-vehicle/issues",
   "requirements": [
-    "pybyd==0.0.64"
+    "pybyd==0.0.65"
   ],
   "version": "0.0.77"
 }

--- a/custom_components/byd_vehicle/services.yaml
+++ b/custom_components/byd_vehicle/services.yaml
@@ -37,3 +37,11 @@ fetch_energy:
       selector:
         device:
           integration: byd_vehicle
+
+start_charging:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: byd_vehicle

--- a/custom_components/byd_vehicle/strings.json
+++ b/custom_components/byd_vehicle/strings.json
@@ -396,6 +396,9 @@
       },
       "force_poll": {
         "name": "Force poll"
+      },
+      "start_charging": {
+        "name": "Start charging"
       }
     },
     "select": {

--- a/custom_components/byd_vehicle/translations/en.json
+++ b/custom_components/byd_vehicle/translations/en.json
@@ -395,6 +395,9 @@
       },
       "force_poll": {
         "name": "Force poll"
+      },
+      "start_charging": {
+        "name": "Start charging"
       }
     },
     "select": {


### PR DESCRIPTION
## Summary

Wires `BydCar.start_charging()` from pybyd `0.0.65` into the integration: a Start Charging button, a matching `byd_vehicle.start_charging` service, and a coordinator method that maps pybyd exceptions to `HomeAssistantError`. The button auto-disables when the vehicle is already charging or at 100 % SoC so users don't hit the cloud's `res=3` "already in target state" reject.

The underlying pybyd flow is MQTT-first with HTTP polling fallback (jkaberg/pyBYD#32).

## Changes

- `manifest.json` — bumps `pybyd==0.0.64` → `pybyd==0.0.65` (the release containing `start_charging`).
- `coordinator.py` — `async_start_charging()` maps `BydEndpointNotSupportedError`, `BydRemoteControlError`, `BydAuthenticationError`, `BydApiError`, `BydTransportError` to `HomeAssistantError` so service callers see a loud failure rather than a silent no-op. Refreshes the charging snapshot on success.
- `button.py` — `BydStartChargingButton` calls `coordinator.async_start_charging()`. `available` reads `realtime.is_charging` / `realtime.elec_percent` (falling back to `charging.is_charging` / `charging.soc`) so the button hides when the vehicle is already charging or at 100 % SoC.
- `__init__.py` — registers the `byd_vehicle.start_charging` service.
- `services.yaml`, `strings.json`, `translations/en.json` — service definition + button name.

## ⚠️ Version field not bumped

`manifest.json`'s `version` is left at `0.0.77` — happy for you to pick the bump on merge (presumably `0.0.78`).

## Test plan

- [x] Start Charging on a plugged-in BYD SHARK (AU) — terminal `res:2` settles in ~2 s via the MQTT `smartCharge` push, charging snapshot refreshes
- [x] Start Charging at 100 % SoC — surfaces pybyd's friendlier `res=3` "already in target state" error; button goes unavailable once `realtime.elec_percent` hits 100
- [x] Start Charging while already charging — button goes unavailable on `realtime.is_charging`
- [x] `ruff check .` and `black --check .` pass

## Notes

`mypy .` reports 6 errors that are pre-existing on `upstream/main` (config_flow.py:124, coordinator.py:461/730/870/914/915) — not introduced here.

This button has been tested against a Shark 6 with Smart Charging enabled. Feel free to tag me in any edge cases for other vehicles.