### PR TITLE
fix temp_in_car reporting 0 instead of unknown on sentinel

### DIFF
--- a/custom_components/byd_vehicle/sensor.py
+++ b/custom_components/byd_vehicle/sensor.py
@@ -351,9 +351,7 @@ SENSOR_DESCRIPTIONS: tuple[BydSensorDescription, ...] = (
         suggested_display_precision=0,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda obj: (
-            int(round(obj.temp_in_car)) if obj.temp_in_car is not None else 0
-        ),
+        value_fn=_round_int_attr("temp_in_car"),
     ),
     # Tire pressures – unit resolved dynamically from tire_press_unit;
     # kPa is the default because most BYD vehicles report tirePressUnit=3.


### PR DESCRIPTION
The temp_in_car value_fn coerced None (the sentinel-cleaned value when the API returns -129) to literal 0, so the cabin_temperature sensor showed 0 C in HA instead of going unknown.

Root cause: HTTP /vehicleRealTimeResult sometimes carries tempInCar=-129 while other gating fields (enduranceMileage, time, tire pressure) are populated enough that is_ready_raw accepts the payload (see capture schedule_0105_to_0600/00_00_http_realtime.json). pyBYD correctly maps the -129 sentinel to None, but the sensor description then substituted 0 instead of propagating None to HA.

Switch to the existing _round_int_attr helper, which returns None for None inputs and matches the convention used by every other rounded temperature/distance sensor in this file.

## Summary
- What changed and why?

## Linked issue
- Closes #

## Logs (required, redacted)
- Include relevant logs that prove behavior before/after this change.
- Remove sensitive values (VIN, tokens, email, account identifiers).

## End-to-end test (required for new/changed functionality)
- Describe the full user flow tested in Home Assistant.
- Include exact steps and observed result.

## Validation
- [ ] I attached relevant redacted logs.
- [ ] I documented end-to-end test steps and results for the functionality I added/changed.
- [ ] I ran applicable local checks (ruff, black, mypy) and they pass.
