### PR TITLE
add _vendor/ pybyd override bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,9 @@ cython_debug/
 # Local Home Assistant docker dev runtime
 .ha-dev/
 
+# Vendored pyBYD override (local dev only — see HA_LOCAL_OVERRIDE.md)
+custom_components/byd_vehicle/_vendor/
+
 # PyPI configuration file
 .pypirc
 

--- a/custom_components/byd_vehicle/__init__.py
+++ b/custom_components/byd_vehicle/__init__.py
@@ -2,6 +2,23 @@
 
 from __future__ import annotations
 
+# _vendor/ override: if a sibling _vendor/ directory exists, prepend it to
+# sys.path and evict any already-imported pybyd modules so the next
+# ``import pybyd`` resolves to the vendored copy. No-op when absent, so
+# the manifest-pinned pybyd is used. See HA_LOCAL_OVERRIDE.md.
+import sys as _sys
+from pathlib import Path as _Path
+
+_vendor_path = _Path(__file__).parent / "_vendor"
+if _vendor_path.is_dir():
+    _vendor_str = str(_vendor_path)
+    if _vendor_str not in _sys.path:
+        _sys.path.insert(0, _vendor_str)
+    for _name in list(_sys.modules):
+        if _name == "pybyd" or _name.startswith("pybyd."):
+            del _sys.modules[_name]
+del _sys, _Path, _vendor_path
+
 import logging
 from typing import Any
 


### PR DESCRIPTION
Lets a sibling custom_components/byd_vehicle/_vendor/ directory shadow the manifest-pinned pybyd at import time. The bootstrap prepends _vendor/ to sys.path and evicts any already-imported pybyd modules so the next `import pybyd` resolves through the vendored copy. When _vendor/ is absent the bootstrap is a no-op and the manifest-pinned version is used unchanged.

Used for testing in-progress pyBYD changes against a running HA without rebuilding HA's venv. Reversible by deleting _vendor/ — see HA_LOCAL_OVERRIDE.md for the full runbook.

_vendor/ is gitignored so a local copy never accidentally lands in a commit; only the bootstrap itself ships with the integration.

## Summary
- What changed and why?

## Linked issue
- Closes #

## Logs (required, redacted)
- Include relevant logs that prove behavior before/after this change.
- Remove sensitive values (VIN, tokens, email, account identifiers).

## End-to-end test (required for new/changed functionality)
- Describe the full user flow tested in Home Assistant.
- Include exact steps and observed result.

## Validation
- [ ] I attached relevant redacted logs.
- [ ] I documented end-to-end test steps and results for the functionality I added/changed.
- [ ] I ran applicable local checks (ruff, black, mypy) and they pass.
