### PR TITLE
fix: source plug + charging_state from charging endpoint (Sealion 7 EU)

### DIFF
--- a/custom_components/byd_vehicle/binary_sensor.py
+++ b/custom_components/byd_vehicle/binary_sensor.py
@@ -96,6 +96,15 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[BydBinarySensorDescription, ...] = (
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
         value_fn=_is_charging_from_realtime,
     ),
+    # Plug/charger connection.  Reads from the smart-charging endpoint
+    # because the realtime payload reports ``connectState=-1``
+    # permanently on Sealion 7 (and other EU 2024 cars) — see issue #115.
+    BydBinarySensorDescription(
+        key="is_charger_connected",
+        source="charging",
+        device_class=BinarySensorDeviceClass.PLUG,
+        value_fn=lambda c: c.is_connected if c is not None else None,
+    ),
     BydBinarySensorDescription(
         key="is_any_door_open",
         source="realtime",

--- a/custom_components/byd_vehicle/sensor.py
+++ b/custom_components/byd_vehicle/sensor.py
@@ -465,9 +465,14 @@ SENSOR_DESCRIPTIONS: tuple[BydSensorDescription, ...] = (
         value_fn=_round_int_attr("total_mileage_v2"),
     ),
     # Charging detail from realtime
+    # Source the charging-state value from the smart-charging endpoint:
+    # the realtime payload reports ``chargingState=-1`` permanently on
+    # Sealion 7 (and other EU 2024 cars) while the charging endpoint
+    # returns the real numeric state (15=connected, 1=charging, …).
+    # See issue #115.
     BydSensorDescription(
         key="charging_state",
-        source="realtime",
+        source="charging",
         icon="mdi:ev-station",
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,


### PR DESCRIPTION
Closes the two confirmed bugs in #115 with surgical changes.

## Bugs

On BYD Sealion 7 Comfort 2024 EU (and likely other EU 2024 models), the realtime endpoint returns sentinel `-1` for both `connectState` and `chargingState` permanently — even while the car is actively connected/charging. The real values live in the smart-charging endpoint payload (`charging.connect_state`, `charging.charging_state`), which is already fetched by the integration.

The result on these cars: `sensor.byd_<vin>_charging_state` shows `-1` always, and `binary_sensor.byd_<vin>_plug` was never instantiated.

## Changes

- **`sensor.py`** — `charging_state` source: `realtime` → `charging`.
- **`binary_sensor.py`** — add `is_charger_connected` reading from `charging.connect_state` (device_class PLUG).

Both fixes are 1-line code changes plus a short why-comment.

## Validation

Live test on Sealion 7 Comfort 2024 EU:

| Before | After |
|---|---|
| `charging_state`: `-1` (constant) | `charging_state`: `15` (connected) / `1` (charging) |
| `plug`: never emitted | `plug`: `off` (unplugged) / `on` (connected) |

Other items in #115 (energy distribution detection, tire status sentinel handling, battery heat semantics) involve more invasive changes and are deferred to a follow-up PR.