### PR TITLE
Add support for charging schedule control.

### DIFF
--- a/custom_components/byd_vehicle/const.py
+++ b/custom_components/byd_vehicle/const.py
@@ -16,6 +16,7 @@ PLATFORMS: list[Platform] = [
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.TIME,
 ]
 
 CONF_BASE_URL = "base_url"

--- a/custom_components/byd_vehicle/coordinator.py
+++ b/custom_components/byd_vehicle/coordinator.py
@@ -457,6 +457,9 @@ class BydDataUpdateCoordinator(DataUpdateCoordinator[VehicleSnapshot]):
         self._car: BydCar | None = None
         self._realtime_endpoint_unsupported: bool = False
         self._cancel_hvac_final_retry: CALLBACK_TYPE | None = None
+        self.update_pending: bool = False
+        self._debounce_timer: CALLBACK_TYPE | None = None
+        self._pending_schedule_updates: dict[str, Any] = {}
 
     # ------------------------------------------------------------------
     # State-engine push
@@ -633,6 +636,12 @@ class BydDataUpdateCoordinator(DataUpdateCoordinator[VehicleSnapshot]):
         self._force_next_refresh = False
         previous_snapshot = self.data
 
+        if self.update_pending:
+            _LOGGER.debug("Skipping telemetry refresh due to pending schedule update: vin=%s", self._vin[-6:])
+            if self.data is not None:
+                return self.data
+            return VehicleSnapshot(vehicle=self._vehicle)
+
         if not self._polling_enabled and not force:
             if self.data is not None:
                 return self.data
@@ -679,6 +688,18 @@ class BydDataUpdateCoordinator(DataUpdateCoordinator[VehicleSnapshot]):
             _LOGGER.debug(
                 "HVAC fetch skipped: vin=%s, reason=vehicle_not_on",
                 self._vin[-6:],
+            )
+
+        # --- Charging (Schedule & Live) ---
+        try:
+            await car.update_charging()
+        except _AUTH_ERRORS:
+            raise
+        except _RECOVERABLE_ERRORS as exc:
+            _LOGGER.warning(
+                "Charging fetch failed: vin=%s, error=%s",
+                self._vin,
+                exc,
             )
 
         snapshot = car.state
@@ -828,6 +849,88 @@ class BydDataUpdateCoordinator(DataUpdateCoordinator[VehicleSnapshot]):
                 self._vin,
                 exc,
             )
+
+    async def async_request_schedule_update(self, property_name: str, new_value: Any) -> None:
+        """Queue a debounced update for the charging schedule."""
+        self._pending_schedule_updates[property_name] = new_value
+
+        if self._debounce_timer is not None:
+            self._debounce_timer()
+            self._debounce_timer = None
+
+        self.update_pending = True
+
+        @callback
+        def _execute_update(_now: Any) -> None:
+            self._debounce_timer = None
+            self.hass.async_create_task(self._async_execute_schedule_update())
+
+        self._debounce_timer = async_call_later(
+            self.hass,
+            10.0,
+            _execute_update,
+        )
+
+    async def _async_execute_schedule_update(self) -> None:
+        """Execute the pending schedule update."""
+        if not self._pending_schedule_updates:
+            self.update_pending = False
+            return
+
+        current_enabled = True
+        current_charge_to_full = True
+        current_start_time = "22:00"
+        current_end_time = "full"
+        current_charge_way = "e"
+
+        if self.data and self.data.charging_schedule and self.data.charging_schedule.charge:
+            charge = self.data.charging_schedule.charge
+            if charge.status is not None:
+                current_enabled = charge.status
+            if charge.charge_until_full is not None:
+                current_charge_to_full = charge.charge_until_full
+            
+            if charge.start_time is not None:
+                current_start_time = charge.start_time.strftime("%H:%M")
+            if charge.end_time is not None:
+                current_end_time = charge.end_time.strftime("%H:%M")
+                
+            if charge.charge_way is not None:
+                current_charge_way = charge.charge_way
+
+        updates = self._pending_schedule_updates
+        
+        enabled = updates.get("enabled", current_enabled)
+        charge_to_full = updates.get("charge_to_full", current_charge_to_full)
+        pattern = updates.get("pattern", current_charge_way)
+        start_time_obj = updates.get("start_time")
+        end_time_obj = updates.get("end_time")
+
+        start_charge_time = start_time_obj.strftime("%H:%M") if start_time_obj else current_start_time
+        
+        if charge_to_full:
+            end_charge_time = "full"
+        else:
+            end_charge_time = end_time_obj.strftime("%H:%M") if end_time_obj else current_end_time
+            if end_charge_time == "full":
+                end_charge_time = "06:00"
+
+        charge_way = pattern
+
+        self._pending_schedule_updates.clear()
+
+        try:
+            await self.async_save_charging_schedule(
+                start_charge_time=start_charge_time,
+                end_charge_time=end_charge_time,
+                charge_way=charge_way,
+                enabled=enabled,
+            )
+        except Exception as exc:
+            _LOGGER.error("Debounced schedule save failed: %s", exc)
+        finally:
+            self.update_pending = False
+            await self.async_request_refresh()
 
     async def async_save_charging_schedule(
         self,

--- a/custom_components/byd_vehicle/switch.py
+++ b/custom_components/byd_vehicle/switch.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -40,6 +40,10 @@ async def async_setup_entry(
             entities.append(BydBatteryHeatSwitch(coordinator, vin, vehicle))
         if coordinator.capability_available("steering_wheel_heat"):
             entities.append(BydSteeringWheelHeatSwitch(coordinator, vin, vehicle))
+
+        entities.append(BydScheduleEnabledSwitch(coordinator, vin, vehicle))
+        entities.append(BydChargeToFullSwitch(coordinator, vin, vehicle))
+        entities.append(BydRepeatDailySwitch(coordinator, vin, vehicle))
 
     async_add_entities(entities)
 
@@ -299,3 +303,141 @@ class BydDisablePollingSwitch(BydVehicleEntity, RestoreEntity, SwitchEntity):
         """Re-enable polling."""
         self._disabled = False
         await self._apply()
+
+
+class BydScheduleEnabledSwitch(BydVehicleEntity, SwitchEntity):
+    """Switch to enable/disable the charging schedule."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "schedule_enabled"
+    _attr_icon = "mdi:calendar-clock"
+
+    def __init__(
+        self,
+        coordinator: BydDataUpdateCoordinator,
+        vin: str,
+        vehicle: Vehicle,
+    ) -> None:
+        super().__init__(coordinator)
+        self._vin = vin
+        self._vehicle = vehicle
+        self._attr_unique_id = f"{vin}_switch_schedule_enabled"
+        self._optimistic_state: bool | None = None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if schedule is enabled."""
+        if self._optimistic_state is not None:
+            return self._optimistic_state
+        if self.coordinator.data and self.coordinator.data.charging_schedule and self.coordinator.data.charging_schedule.charge:
+            return self.coordinator.data.charging_schedule.charge.status
+        return None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._optimistic_state = None
+        super()._handle_coordinator_update()
+
+    async def async_turn_on(self, **_kwargs: Any) -> None:
+        """Enable schedule."""
+        self._optimistic_state = True
+        self.async_write_ha_state()
+        await self.coordinator.async_request_schedule_update("enabled", True)
+
+    async def async_turn_off(self, **_kwargs: Any) -> None:
+        """Disable schedule."""
+        self._optimistic_state = False
+        self.async_write_ha_state()
+        await self.coordinator.async_request_schedule_update("enabled", False)
+
+
+class BydChargeToFullSwitch(BydVehicleEntity, SwitchEntity):
+    """Switch to toggle whether to charge to 100% or stop at end_time."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "charge_to_full"
+    _attr_icon = "mdi:battery-charging-100"
+
+    def __init__(
+        self,
+        coordinator: BydDataUpdateCoordinator,
+        vin: str,
+        vehicle: Vehicle,
+    ) -> None:
+        super().__init__(coordinator)
+        self._vin = vin
+        self._vehicle = vehicle
+        self._attr_unique_id = f"{vin}_switch_charge_to_full"
+        self._optimistic_state: bool | None = None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if charging to full."""
+        if self._optimistic_state is not None:
+            return self._optimistic_state
+        if self.coordinator.data and self.coordinator.data.charging_schedule and self.coordinator.data.charging_schedule.charge:
+            return self.coordinator.data.charging_schedule.charge.charge_until_full
+        return None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._optimistic_state = None
+        super()._handle_coordinator_update()
+
+    async def async_turn_on(self, **_kwargs: Any) -> None:
+        """Turn on charge to full."""
+        self._optimistic_state = True
+        self.async_write_ha_state()
+        await self.coordinator.async_request_schedule_update("charge_to_full", True)
+
+    async def async_turn_off(self, **_kwargs: Any) -> None:
+        """Turn off charge to full."""
+        self._optimistic_state = False
+        self.async_write_ha_state()
+        await self.coordinator.async_request_schedule_update("charge_to_full", False)
+
+
+class BydRepeatDailySwitch(BydVehicleEntity, SwitchEntity):
+    """Switch to toggle daily repeat (True for 'e', False for 's')."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "repeat_daily"
+    _attr_icon = "mdi:repeat"
+
+    def __init__(
+        self,
+        coordinator: BydDataUpdateCoordinator,
+        vin: str,
+        vehicle: Vehicle,
+    ) -> None:
+        super().__init__(coordinator)
+        self._vin = vin
+        self._vehicle = vehicle
+        self._attr_unique_id = f"{vin}_switch_repeat_daily"
+        self._optimistic_state: bool | None = None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if repeat is daily."""
+        if self._optimistic_state is not None:
+            return self._optimistic_state
+        if self.coordinator.data and self.coordinator.data.charging_schedule and self.coordinator.data.charging_schedule.charge:
+            return self.coordinator.data.charging_schedule.charge.charge_way == "e"
+        return None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._optimistic_state = None
+        super()._handle_coordinator_update()
+
+    async def async_turn_on(self, **_kwargs: Any) -> None:
+        """Turn on repeat daily."""
+        self._optimistic_state = True
+        self.async_write_ha_state()
+        await self.coordinator.async_request_schedule_update("pattern", "e")
+
+    async def async_turn_off(self, **_kwargs: Any) -> None:
+        """Turn off repeat daily."""
+        self._optimistic_state = False
+        self.async_write_ha_state()
+        await self.coordinator.async_request_schedule_update("pattern", "s")

--- a/custom_components/byd_vehicle/time.py
+++ b/custom_components/byd_vehicle/time.py
@@ -1,0 +1,114 @@
+"""Time entities for BYD Vehicle."""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+from homeassistant.components.time import TimeEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from pybyd.models.vehicle import Vehicle
+
+from .const import DOMAIN
+from .coordinator import BydDataUpdateCoordinator
+from .entity import BydVehicleEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up BYD time entities from a config entry."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinators: dict[str, BydDataUpdateCoordinator] = data["coordinators"]
+
+    entities: list[TimeEntity] = []
+    for vin, coordinator in coordinators.items():
+        vehicle = coordinator.vehicle
+        entities.append(BydStartTimeEntity(coordinator, vin, vehicle))
+        entities.append(BydEndTimeEntity(coordinator, vin, vehicle))
+
+    async_add_entities(entities)
+
+
+class BydStartTimeEntity(BydVehicleEntity, TimeEntity):
+    """Time entity for charging start time."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "start_time"
+    _attr_icon = "mdi:clock-start"
+
+    def __init__(
+        self,
+        coordinator: BydDataUpdateCoordinator,
+        vin: str,
+        vehicle: Vehicle,
+    ) -> None:
+        super().__init__(coordinator)
+        self._vin = vin
+        self._vehicle = vehicle
+        self._attr_unique_id = f"{vin}_time_start_time"
+        self._optimistic_state: datetime.time | None = None
+
+    @property
+    def native_value(self) -> datetime.time | None:
+        """Return the start time."""
+        if self._optimistic_state is not None:
+            return self._optimistic_state
+        if self.coordinator.data and self.coordinator.data.charging_schedule and self.coordinator.data.charging_schedule.charge:
+            return self.coordinator.data.charging_schedule.charge.start_time
+        return None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._optimistic_state = None
+        super()._handle_coordinator_update()
+
+    async def async_set_value(self, value: datetime.time) -> None:
+        """Set the start time."""
+        self._optimistic_state = value
+        self.async_write_ha_state()
+        await self.coordinator.async_request_schedule_update("start_time", value)
+
+
+class BydEndTimeEntity(BydVehicleEntity, TimeEntity):
+    """Time entity for charging end time."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "end_time"
+    _attr_icon = "mdi:clock-end"
+
+    def __init__(
+        self,
+        coordinator: BydDataUpdateCoordinator,
+        vin: str,
+        vehicle: Vehicle,
+    ) -> None:
+        super().__init__(coordinator)
+        self._vin = vin
+        self._vehicle = vehicle
+        self._attr_unique_id = f"{vin}_time_end_time"
+        self._optimistic_state: datetime.time | None = None
+
+    @property
+    def native_value(self) -> datetime.time | None:
+        """Return the end time."""
+        if self._optimistic_state is not None:
+            return self._optimistic_state
+        if self.coordinator.data and self.coordinator.data.charging_schedule and self.coordinator.data.charging_schedule.charge:
+            return self.coordinator.data.charging_schedule.charge.end_time
+        return None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._optimistic_state = None
+        super()._handle_coordinator_update()
+
+    async def async_set_value(self, value: datetime.time) -> None:
+        """Set the end time."""
+        self._optimistic_state = value
+        self.async_write_ha_state()
+        await self.coordinator.async_request_schedule_update("end_time", value)

--- a/custom_components/byd_vehicle/translations/en.json
+++ b/custom_components/byd_vehicle/translations/en.json
@@ -576,6 +576,23 @@
       },
       "disable_polling": {
         "name": "Disable polling"
+      },
+      "schedule_enabled": {
+        "name": "Schedule enabled"
+      },
+      "charge_to_full": {
+        "name": "Charge to full"
+      },
+      "repeat_daily": {
+        "name": "Repeat daily"
+      }
+    },
+    "time": {
+      "start_time": {
+        "name": "Start time"
+      },
+      "end_time": {
+        "name": "End time"
       }
     },
     "climate": {


### PR DESCRIPTION
## Summary
Added entities to expose charging schedule controls:

- Switches:
  1. Charging schedule enable
  2. Charge to full (ignore schedule end time)
  3. Repeat schedule daily
- Time selectors:
  1. Schedule start time
  2. Schedule end time

To avoid "chatty API", schedule updates are applied only if all of the schedule entities remain stable for at least 10 seconds.

## End-to-end test
I tried toggling charging schedule on/off and modifying its parameters in the BYD app, and noticing changes reflected in the respective Home Assistant entities.
I tried toggling charging schedule on/off and modifying its parameters in the Home Assistant entities, and noticing changes reflected the BYD app.