### PR TITLE
fix(sensor): strip -1 sentinels on epb and power_battery_connection

### DIFF
--- a/custom_components/byd_vehicle/sensor.py
+++ b/custom_components/byd_vehicle/sensor.py
@@ -617,6 +617,14 @@ SENSOR_DESCRIPTIONS: tuple[BydSensorDescription, ...] = (
     BydSensorDescription(
         key="epb",
         source="realtime",
+        # The ``epb`` field returns ``-1`` while the car is asleep or
+        # otherwise unable to report EPB state; without this guard the
+        # diagnostic sensor surfaces a literal ``-1`` as its state.
+        value_fn=lambda obj: (
+            None
+            if obj is None or not isinstance(getattr(obj, "raw", None), dict)
+            else (None if obj.raw.get("epb", -1) < 0 else obj.raw.get("epb"))
+        ),
         icon="mdi:car-brake-parking",
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -729,6 +737,18 @@ SENSOR_DESCRIPTIONS: tuple[BydSensorDescription, ...] = (
     BydSensorDescription(
         key="power_battery_connection",
         source="realtime",
+        # Mirrors the ``epb`` guard above: this field reports ``-1``
+        # while telemetry is stale and surfaces as a literal ``-1``
+        # state on the diagnostic sensor without filtering.
+        value_fn=lambda obj: (
+            None
+            if obj is None or not isinstance(getattr(obj, "raw", None), dict)
+            else (
+                None
+                if obj.raw.get("powerBatteryConnection", -1) < 0
+                else obj.raw.get("powerBatteryConnection")
+            )
+        ),
         icon="mdi:battery-alert",
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,


### PR DESCRIPTION
## Summary

Two diagnostic descriptors — `sensor.<vin>_electronic_parking_brake` (key `epb`) and `sensor.<vin>_power_battery_connection` — were reading the raw realtime attribute without filtering BYD's `-1` "not available" sentinel.  When a user enables either entity in the registry, the state surfaces as a literal `-1`, indistinguishable from a real reading.

## Live capture (BYD Sealion 7 Comfort 2024 EU, `pybyd 0.0.67`)

Both entities enabled in the registry, car parked unplugged, charging-off:

```
sensor.byd_sealion_7_electronic_parking_brake = -1
sensor.byd_sealion_7_power_battery_connection = -1
```

The `-1` persists until the car wakes up for a poll that returns a real value (`0` released / `1` engaged for EPB).  In practice on this VIN that's hours — the realtime HTTP endpoint stays unsupported and MQTT pushes are infrequent.

## Fix

Add a `value_fn` that returns `None` when the raw value is negative.  Mirrors the same pattern already used by other diagnostic sensors in this file that guard sentinel values — `endurance_mileage_v2`, `ev_endurance`, etc.

Purely additive: entities that previously got `-1` now get `unknown` until the cloud reports a real value.  No new sensors, no schema changes, no entity-registry migration needed.

## Test plan

### Local checks pass

```
$ ruff check custom_components/byd_vehicle/sensor.py
All checks passed!

$ black --check custom_components/byd_vehicle/sensor.py
All done! ✨ 🍰 ✨
1 file would be left unchanged.

$ mypy custom_components/byd_vehicle/sensor.py
# Same diagnostics as main (preexisting coordinator.py warnings); no new errors introduced by this change.
```

### Reproduction

1. Enable `sensor.<vin>_electronic_parking_brake` and `sensor.<vin>_power_battery_connection` in the entity registry on a Sealion 7 EU.
2. Wait for the car to be asleep / restart HA before the car wakes.
3. Before fix: both sensors read `-1`.  After fix: both read `unknown` until the car reports a real value.

### Edge cases

- `obj.raw` missing or not a dict → returns `None` (no AttributeError).
- `obj.raw["epb"]` / `obj.raw["powerBatteryConnection"]` missing → defaults to `-1` (treated as sentinel) → returns `None`.
- Positive integer values pass through unchanged.

## 🤖 AI disclosure

Drafted with Claude Code assistance; the sentinel-strip pattern is copied verbatim from neighbouring descriptors in the same file (no new abstraction), the field-name choice (`epb` / `powerBatteryConnection`) is taken from the actual realtime payload, and the live capture above came from validating the fix on a real Sealion 7 (the dashboard rendering literal `-1` is what surfaced the bug in the first place).  Happy to amend the diff shape if you'd prefer a smaller helper to dedupe the two lambdas.