### PR TITLE
Documentation: Add tip regarding battery drain from polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Configuration is UI-only via Home Assistant config flow.
 
 Entity updates are cloud-polled, poll intervals are exposed as entities and can be tuned using automations.
 
+> [!TIP]
+> Frequent polling can cause noticeable battery drain. Adjust the polling interval to find your ideal balance between real-time updates and battery drain.
+
 ## Documentation
 
 - Troubleshooting: [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)


### PR DESCRIPTION
During my testing, I was able to check battery drain for a vehicle that wasn't used for 3 whole days.
I've noticed that for a period of 60h with no polls, there was 0% battery drain.
Then, for a period of 12h with the default 5m poll interval, there was 3% battery drain, which I feel is significant.

Therefore, I felt it was necessary to add a tip to README.md about battery drain due to frequent polling.

It might be fitting to set a longer poll interval than 5m by default.
