### PR TITLE
fix(switch): reflect steering-wheel heat state while parked

### DIFF
--- a/custom_components/byd_vehicle/switch.py
+++ b/custom_components/byd_vehicle/switch.py
@@ -199,9 +199,12 @@ class BydSteeringWheelHeatSwitch(BydActionEntity, SwitchEntity):
 
     @property
     def is_on(self) -> bool | None:
-        """Return whether steering wheel heating is on."""
-        if not self._is_vehicle_on():
-            return False
+        """Return whether steering wheel heating is on.
+
+        No ``_is_vehicle_on()`` gate: steering-wheel pre-heat is used
+        precisely while the car is parked/off, so the state must reflect
+        the HVAC/realtime heating flag regardless of power state.
+        """
         hvac = self._get_hvac_status()
         if hvac is not None:
             val = hvac.is_steering_wheel_heating


### PR DESCRIPTION
## What
`BydSteeringWheelHeatSwitch.is_on` short-circuits to `False` whenever the vehicle isn't "on" (`power_gear != ON`). But steering-wheel pre-heat is used **precisely while the car is parked**, so the switch always reads `off` — even with the heater physically running.

Drop the `_is_vehicle_on()` gate so `is_on` reflects the `is_steering_wheel_heating` flag from HVAC/realtime directly (the rest of the method, and `assumed_state`, are unchanged).

## Why it's safe
- When off, the HVAC/realtime flag is `False`, so the switch still reads `off` (no regression).
- The `Enum | int` flag is read the same way it already was.

## Tested
On a real Sealion 7 (parked): toggling the switch **on** heats the wheel and the entity now correctly reads `on`; toggling **off** reads `off`. Previously it stayed `off` in both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
