### PR TITLE
fix(button): gate Start charging by plug state

### DIFF
--- a/custom_components/byd_vehicle/button.py
+++ b/custom_components/byd_vehicle/button.py
@@ -164,9 +164,9 @@ class BydStartChargingButton(BydVehicleEntity, ButtonEntity):
     def available(self) -> bool:
         # BYD's cloud rejects /control/smartCharge/changeChargeStatue with
         # res=3 "Operation failure" when the vehicle is already in the
-        # target state — either already charging, or at 100 % SoC with
-        # nothing to charge (see references/changeResult.md). Hide the
-        # button in those cases so users don't get a confusing error.
+        # target state — either already charging, at 100 % SoC, or when
+        # the cable isn't physically plugged in.  Hide the button in
+        # those cases so users don't get a confusing error.
         #
         # Prefer realtime fields (always present, drive the user-visible
         # battery_level / charging sensors) over the charging snapshot
@@ -191,6 +191,14 @@ class BydStartChargingButton(BydVehicleEntity, ButtonEntity):
             soc = snapshot.charging.soc
         if soc is not None and soc >= 100:
             return False
+        # Cable must be plugged in.  Source from the charging endpoint
+        # which PR #144 made the authoritative plug state — realtime's
+        # connectState frequently sits at -1 (sentinel) on Sealion 7 EU
+        # so we only treat charging.connect_state as a hard "no".
+        if snapshot.charging is not None:
+            connect_state = getattr(snapshot.charging, "connect_state", None)
+            if connect_state is not None and not connect_state:
+                return False
         return True
 
     async def async_press(self) -> None:


### PR DESCRIPTION
## Problem

Pressing **Start charging** while the cable is not physically plugged in sends the command to BYD and gets a `res=3 "Operation failure"` rejection. The user sees no visible result and concludes the button is broken.

## Root cause

`BydStartChargingButton.available` only filtered "already charging" and "SoC ≥ 100", not "cable disconnected".

On Sealion 7 EU, `realtime.connectState` sits permanently at `-1` (sentinel), so gating by realtime never helped. The authoritative plug state is `charging.connect_state` — the same field #144 made canonical for the `binary_sensor.*_plug` entity.

## Change

Hide the Start-charging button when `charging.connect_state` is a falsy (disconnected) value, in addition to the existing already-charging / 100 % SoC guards. Only `charging.connect_state` is treated as a hard "no" (realtime's sentinel `-1` is ignored), so cars that don't populate it are unaffected.

The Stop button is left as-is (only visible while `is_charging`), so its "nothing to stop" case is already covered.

## Notes

- No new dependency — `charging.connect_state` already ships in the pinned pybyd.
- Pure availability-guard change; `ruff` / `black` clean.