### PR TITLE
fix(entity): route charging source in _get_source_obj

### DIFF
--- a/custom_components/byd_vehicle/entity.py
+++ b/custom_components/byd_vehicle/entity.py
@@ -96,7 +96,7 @@ class BydVehicleEntity(CoordinatorEntity[BydDataUpdateCoordinator]):
         Supported values: ``"realtime"``, ``"hvac"``, ``"gps"``,
         ``"energy"``, ``"energy_cumulative"``, ``"energy_nearest"``,
         ``"energy_self_graph"``, ``"energy_auto_model_graph"``,
-        ``"charging_schedule"``, ``"charging_schedule_charge"``,
+        ``"charging"``, ``"charging_schedule"``, ``"charging_schedule_charge"``,
         ``"charging_schedule_journey"``, ``"snapshot"`` (the full
         :class:`VehicleSnapshot` for cross-section merged value_fn lookups).
         """
@@ -108,6 +108,9 @@ class BydVehicleEntity(CoordinatorEntity[BydDataUpdateCoordinator]):
             return self._get_gps()
         if source == "energy":
             return self._get_energy()
+        if source == "charging":
+            snap = self._snapshot()
+            return snap.charging if snap is not None else None
         if source == "snapshot":
             return self._snapshot()
         if source.startswith("energy_"):


### PR DESCRIPTION
## Summary
- Add missing `"charging"` branch to `_get_source_obj()` so entities sourced from `snapshot.charging` can resolve their data.
- Fixes `is_charger_connected` (plug binary sensor) and `charging_state` sensor being permanently unavailable.
- Realtime `connectState` is unreliable on EU 2024 cars (#115); these entities intentionally use the smart-charging endpoint via `source="charging"`.

## Linked issue
- Related to #115

## Logs (required, redacted)
**Before:** `binary_sensor.*_plug` (`is_charger_connected`) reports `unavailable` even when the vehicle is plugged in and charging. No state changes are recorded in the HA recorder for this entity.

**After:** After reloading the integration, `binary_sensor.*_plug` reports `on`/`off` based on `ChargingStatus.is_connected` from the smart-charging snapshot.

## End-to-end test (required for new/changed functionality)
1. Install/upgrade integration with this patch.
2. Reload the BYD Vehicle integration (or restart HA).
3. Plug the vehicle in at home.
4. Observe `binary_sensor.<vehicle>_plug` — should show `on` (not `unavailable`).
5. Unplug — should show `off`.
6. Optionally enable `sensor.<vehicle>_charging_state` (diagnostic) — should report numeric charging state instead of staying unavailable.

## Validation
- [x] I attached relevant redacted logs.
- [x] I documented end-to-end test steps and results for the functionality I added/changed.
- [x] I ran applicable local checks (ruff, black, mypy) and they pass.

Made with [Cursor](https://cursor.com)