### PR TITLE
feat(config): raise max poll interval to 8h (was 15m)

### DIFF
--- a/custom_components/byd_vehicle/const.py
+++ b/custom_components/byd_vehicle/const.py
@@ -37,9 +37,13 @@ DEFAULT_COUNTRY = "United Kingdom"
 DEFAULT_LANGUAGE = "en"
 
 MIN_POLL_INTERVAL = 30
-MAX_POLL_INTERVAL = 900
+# 8 hours. Polling wakes the car, so frequent polling drains the traction
+# battery (~0.1 kWh/h at 300 s on a 60 kWh pack); a high ceiling lets users
+# poll sparsely (e.g. once an hour) without relying on external automations.
+# See issue #120.
+MAX_POLL_INTERVAL = 28800
 MIN_GPS_POLL_INTERVAL = 30
-MAX_GPS_POLL_INTERVAL = 900
+MAX_GPS_POLL_INTERVAL = 28800
 
 # Node-to-server mapping based on BYD app reverse engineering.
 # Push server URLs are stored as reference metadata for future usage.


### PR DESCRIPTION
Closes #120.

## Why

Polling wakes the car, so frequent polling drains the traction battery — a user in #120 measured ~0.1 kWh/h at the 300 s default (~3.7% / 2.2 kWh per 24 h on a 60 kWh pack). The current 900 s (15 min) ceiling is too low to poll sparsely, forcing people into external automations that toggle the disable-polling switch + force-poll button just to get a longer effective interval.

## Change

Raise `MAX_POLL_INTERVAL` and `MAX_GPS_POLL_INTERVAL` from `900` to `28800` (8 h) in `const.py`. Both the realtime and GPS poll-interval `number` entities derive their `native_max_value` from these constants, and the option-flow / coordinator clamps use them too, so the one change propagates everywhere.

The number entities are `NumberMode.BOX` (typed value, not a slider), so the wider range stays usable in the UI. `MIN`/`DEFAULT` are unchanged.

The exact value (`28800`) was live-tested with no log errors by the reporter in #120.

ruff / black clean.