### PR TITLE
  Adds an `open_windows` button mirroring the existing `close_windows…

### DIFF
--- a/custom_components/byd_vehicle/button.py
+++ b/custom_components/byd_vehicle/button.py
@@ -49,6 +49,12 @@ BUTTON_DESCRIPTIONS: tuple[BydButtonDescription, ...] = (
         capability_key="close_windows",
         car_command=lambda car: car.windows.close(),
     ),
+    BydButtonDescription(
+        key="open_windows",
+        icon="mdi:window-open",
+        capability_key="open_windows",
+        car_command=lambda car: car.windows.open(),
+    ),
 )
 
 

--- a/custom_components/byd_vehicle/strings.json
+++ b/custom_components/byd_vehicle/strings.json
@@ -489,6 +489,9 @@
       "close_windows": {
         "name": "Close windows"
       },
+      "open_windows": {
+        "name": "Open windows"
+      },
       "force_poll": {
         "name": "Force poll"
       },


### PR DESCRIPTION
## Summary
  Adds an `open_windows` ("Open windows") button, mirroring the existing
  `close_windows` button.

  `pybyd` already exposes `car.windows.open()` and an `open_windows` capability
  flag, but the integration only surfaced the close command — so there was no way
  to remotely vent the windows from Home Assistant.

  `windows.open()` sends `RemoteCommand.OPEN_WINDOWS` ("OPENWINDOW"), which cracks
  all windows to a ~10% vent (BYD's native "window ajar" / ventilation mode), useful
  for cooling a sun-baked cabin. There is no known remote full-drop command, so this
  is the full extent of remote window opening the API supports — hence no position
  parameter. Like the close button, it's gated by `capability_available("open_windows")`,
  so it only appears on vehicles that report the capability.

  ## Linked issue
  - Closes # (none — no existing issue)

  ## Logs (required, redacted)
  Debug logging enabled for `custom_components.byd_vehicle` + `pybyd`. VIN, user id
  and GPS redacted. Tested on a BYD Sealion 7 (EU).

  Command round-trip (button press -> BYD cloud -> MQTT ack):
  [pybyd._api.control] Remote control OPEN_WINDOWS: controlState=None serial=2124BD848D5F414F8C6A018CB74576E1
  [pybyd._api.control] Remote control OPEN_WINDOWS resolved via MQTT success=True state=1
  [byd_vehicle.coordinator] Command lifecycle event: vin= serial=2124BD84... status=registered
  [byd_vehicle.coordinator] Command lifecycle event: vin= serial=2124BD84... status=matched
  [byd_vehicle.coordinator] Command ack received: vin= serial=2124BD84... correlated=True success=True result=Função Vidro Entreaberto ativada com sucesso

  Telemetry before (after pressing Close windows) — all windows closed:
  "leftFrontWindow":1,"leftFrontWindowPct":0
  "leftRearWindow":1,"leftRearWindowPct":0
  "rightFrontWindow":1,"rightFrontWindowPct":0
  "rightRearWindow":1,"rightRearWindowPct":0

  Telemetry after (after pressing Open windows) — all windows vented to ~12%:
  "leftFrontWindow":2,"leftFrontWindowPct":12
  "leftRearWindow":2,"leftRearWindowPct":12
  "rightFrontWindow":2,"rightFrontWindowPct":12
  "rightRearWindow":2,"rightRearWindowPct":12

  ## End-to-end test (required for new/changed functionality)
  Vehicle: BYD Sealion 7 (EU). Full restart after adding the entity.

  1. Restarted HA -> entity `button.<...>_open_windows` ("Open windows") created
     (confirms the car reports the `open_windows` capability; entity is gated on it).
  2. Pressed `button.<...>_close_windows`; forced a telemetry poll -> all four
     `*WindowPct` = 0, window state = 1 (closed). Cabin temp 45 °C.
  3. Pressed the new `button.<...>_open_windows`; cloud ack `success=True`
     ("Função Vidro Entreaberto ativada com sucesso").
  4. Forced a telemetry poll -> all four `*WindowPct` = 12, window state = 2 (ajar).
  5. Physically confirmed: all four windows cracked open ~10%.

  Result: PASS. Windows go from fully closed to a ~10% vent on button press.

  ## Validation
  - [x] I attached relevant redacted logs.
  - [x] I documented end-to-end test steps and results for the functionality I added/changed.
  - [x] I ran applicable local checks (ruff, black, mypy) and they pass.