### PR TITLE
feat(button): add Stop charging button (symmetric to Start charging)

### DIFF
--- a/custom_components/byd_vehicle/button.py
+++ b/custom_components/byd_vehicle/button.py
@@ -75,6 +75,7 @@ async def async_setup_entry(
 
         entities.append(BydForcePollButton(coordinator, gps_coordinator, vin, vehicle))
         entities.append(BydStartChargingButton(coordinator, vin, vehicle))
+        entities.append(BydStopChargingButton(coordinator, vin, vehicle))
         entities.append(BydFetchEnergyButton(coordinator, vin, vehicle))
         for description in BUTTON_DESCRIPTIONS:
             if not coordinator.capability_available(description.capability_key):
@@ -209,6 +210,49 @@ class BydStartChargingButton(BydVehicleEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         await self.coordinator.async_start_charging()
+
+
+class BydStopChargingButton(BydVehicleEntity, ButtonEntity):
+    """Button that stops charging immediately."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "stop_charging"
+    _attr_icon = "mdi:stop"
+
+    def __init__(
+        self,
+        coordinator: BydDataUpdateCoordinator,
+        vin: str,
+        vehicle: Vehicle,
+    ) -> None:
+        super().__init__(coordinator)
+        self._vin = vin
+        self._vehicle = vehicle
+        self._attr_unique_id = f"{vin}_button_stop_charging"
+
+    @property
+    def available(self) -> bool:
+        """Only show while the car is actually charging.
+
+        Mirrors the start button's plug/SoC gating: a stop command only
+        makes sense mid-charge, so hide it otherwise (the cloud rejects a
+        stop on an idle car anyway). Prefer realtime fields, fall back to
+        the charging snapshot.
+        """
+        if not super().available:
+            return False
+        snapshot = self._snapshot()
+        if snapshot is None:
+            return False
+        is_charging: bool | None = None
+        if snapshot.realtime is not None:
+            is_charging = snapshot.realtime.is_charging
+        if is_charging is None and snapshot.charging is not None:
+            is_charging = snapshot.charging.is_charging
+        return bool(is_charging)
+
+    async def async_press(self) -> None:
+        await self.coordinator.async_stop_charging()
 
 
 class BydFetchEnergyButton(BydVehicleEntity, ButtonEntity):

--- a/custom_components/byd_vehicle/coordinator.py
+++ b/custom_components/byd_vehicle/coordinator.py
@@ -1079,6 +1079,46 @@ class BydDataUpdateCoordinator(DataUpdateCoordinator[VehicleSnapshot]):
                 exc_info=True,
             )
 
+    async def async_stop_charging(self) -> None:
+        """Stop charging immediately and refresh charging state on success.
+
+        Symmetric to :meth:`async_start_charging`. Raises
+        :class:`HomeAssistantError` on failure (auth, transport, unsupported
+        endpoint, polling timeout) so callers see a loud failure rather than
+        a silent no-op.
+        """
+        if self._car is None:
+            raise HomeAssistantError(
+                f"BYD vehicle {self._vin[-6:]} not ready for charging commands"
+            )
+        try:
+            result = await self._car.stop_charging()
+        except BydEndpointNotSupportedError as exc:
+            raise HomeAssistantError(
+                "stop_charging not supported for this vehicle/region"
+            ) from exc
+        except BydRemoteControlError as exc:
+            raise HomeAssistantError(f"stop_charging failed to settle: {exc}") from exc
+        except BydAuthenticationError as exc:
+            raise HomeAssistantError(f"stop_charging failed (auth): {exc}") from exc
+        except (BydApiError, BydTransportError) as exc:
+            raise HomeAssistantError(f"stop_charging failed: {exc}") from exc
+
+        _LOGGER.info(
+            "stop_charging settled: vin=%s, message=%s",
+            self._vin[-6:],
+            result.message,
+        )
+
+        try:
+            await self._car.update_charging()
+            await self.async_request_refresh()
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "Post-stop_charging refresh failed (non-fatal)",
+                exc_info=True,
+            )
+
 
 class BydGpsUpdateCoordinator(DataUpdateCoordinator[VehicleSnapshot]):
     """Coordinator for GPS updates for a single VIN.

--- a/custom_components/byd_vehicle/strings.json
+++ b/custom_components/byd_vehicle/strings.json
@@ -498,6 +498,9 @@
       "start_charging": {
         "name": "Start charging"
       },
+      "stop_charging": {
+        "name": "Stop charging"
+      },
       "fetch_energy": {
         "name": "Fetch energy data"
       }

--- a/custom_components/byd_vehicle/translations/en.json
+++ b/custom_components/byd_vehicle/translations/en.json
@@ -494,6 +494,9 @@
       "start_charging": {
         "name": "Start charging"
       },
+      "stop_charging": {
+        "name": "Stop charging"
+      },
       "fetch_energy": {
         "name": "Fetch energy data"
       }


### PR DESCRIPTION
Adds a **Stop charging** button entity — the counterpart to the existing Start charging button. Addresses #166 (and the same ask in #167's thread).

## What

- `coordinator.async_stop_charging()` → `car.stop_charging()`, mirroring `async_start_charging`. Raises `HomeAssistantError` on failure (auth / transport / unsupported / settle timeout) so it's a loud failure, not a silent no-op, then refreshes charging state.
- `BydStopChargingButton` (`button.<device>_stop_charging`, `mdi:stop`), `available` only while the car is actually charging (a stop on an idle car is rejected by the cloud anyway).
- `strings.json` + `translations/en.json` entries.

## Dependency

`car.stop_charging()` is already merged in pyBYD (jkaberg/pyBYD#58, hardened in #59) and shipped in **pybyd==0.0.72**, which this integration already pins — so no manifest bump is needed.

## Notes

I've been running this in my fork for a while against a Sealion 7 (EU); stop settles reliably while charging. Kept the diff minimal and matched the Start button's style/gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)