### PR TITLE
fix(button): remove Stop charging button — cloud call always fails, for every vehicle

### DIFF
--- a/custom_components/byd_vehicle/button.py
+++ b/custom_components/byd_vehicle/button.py
@@ -75,7 +75,6 @@ async def async_setup_entry(
 
         entities.append(BydForcePollButton(coordinator, gps_coordinator, vin, vehicle))
         entities.append(BydStartChargingButton(coordinator, vin, vehicle))
-        entities.append(BydStopChargingButton(coordinator, vin, vehicle))
         entities.append(BydFetchEnergyButton(coordinator, vin, vehicle))
         for description in BUTTON_DESCRIPTIONS:
             if not coordinator.capability_available(description.capability_key):
@@ -210,49 +209,6 @@ class BydStartChargingButton(BydVehicleEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         await self.coordinator.async_start_charging()
-
-
-class BydStopChargingButton(BydVehicleEntity, ButtonEntity):
-    """Button that stops charging immediately."""
-
-    _attr_has_entity_name = True
-    _attr_translation_key = "stop_charging"
-    _attr_icon = "mdi:stop"
-
-    def __init__(
-        self,
-        coordinator: BydDataUpdateCoordinator,
-        vin: str,
-        vehicle: Vehicle,
-    ) -> None:
-        super().__init__(coordinator)
-        self._vin = vin
-        self._vehicle = vehicle
-        self._attr_unique_id = f"{vin}_button_stop_charging"
-
-    @property
-    def available(self) -> bool:
-        """Only show while the car is actually charging.
-
-        Mirrors the start button's plug/SoC gating: a stop command only
-        makes sense mid-charge, so hide it otherwise (the cloud rejects a
-        stop on an idle car anyway). Prefer realtime fields, fall back to
-        the charging snapshot.
-        """
-        if not super().available:
-            return False
-        snapshot = self._snapshot()
-        if snapshot is None:
-            return False
-        is_charging: bool | None = None
-        if snapshot.realtime is not None:
-            is_charging = snapshot.realtime.is_charging
-        if is_charging is None and snapshot.charging is not None:
-            is_charging = snapshot.charging.is_charging
-        return bool(is_charging)
-
-    async def async_press(self) -> None:
-        await self.coordinator.async_stop_charging()
 
 
 class BydFetchEnergyButton(BydVehicleEntity, ButtonEntity):

--- a/custom_components/byd_vehicle/coordinator.py
+++ b/custom_components/byd_vehicle/coordinator.py
@@ -1079,46 +1079,6 @@ class BydDataUpdateCoordinator(DataUpdateCoordinator[VehicleSnapshot]):
                 exc_info=True,
             )
 
-    async def async_stop_charging(self) -> None:
-        """Stop charging immediately and refresh charging state on success.
-
-        Symmetric to :meth:`async_start_charging`. Raises
-        :class:`HomeAssistantError` on failure (auth, transport, unsupported
-        endpoint, polling timeout) so callers see a loud failure rather than
-        a silent no-op.
-        """
-        if self._car is None:
-            raise HomeAssistantError(
-                f"BYD vehicle {self._vin[-6:]} not ready for charging commands"
-            )
-        try:
-            result = await self._car.stop_charging()
-        except BydEndpointNotSupportedError as exc:
-            raise HomeAssistantError(
-                "stop_charging not supported for this vehicle/region"
-            ) from exc
-        except BydRemoteControlError as exc:
-            raise HomeAssistantError(f"stop_charging failed to settle: {exc}") from exc
-        except BydAuthenticationError as exc:
-            raise HomeAssistantError(f"stop_charging failed (auth): {exc}") from exc
-        except (BydApiError, BydTransportError) as exc:
-            raise HomeAssistantError(f"stop_charging failed: {exc}") from exc
-
-        _LOGGER.info(
-            "stop_charging settled: vin=%s, message=%s",
-            self._vin[-6:],
-            result.message,
-        )
-
-        try:
-            await self._car.update_charging()
-            await self.async_request_refresh()
-        except Exception:  # noqa: BLE001
-            _LOGGER.debug(
-                "Post-stop_charging refresh failed (non-fatal)",
-                exc_info=True,
-            )
-
 
 class BydGpsUpdateCoordinator(DataUpdateCoordinator[VehicleSnapshot]):
     """Coordinator for GPS updates for a single VIN.

--- a/custom_components/byd_vehicle/strings.json
+++ b/custom_components/byd_vehicle/strings.json
@@ -498,9 +498,6 @@
       "start_charging": {
         "name": "Start charging"
       },
-      "stop_charging": {
-        "name": "Stop charging"
-      },
       "fetch_energy": {
         "name": "Fetch energy data"
       }

--- a/custom_components/byd_vehicle/translations/en.json
+++ b/custom_components/byd_vehicle/translations/en.json
@@ -494,9 +494,6 @@
       "start_charging": {
         "name": "Start charging"
       },
-      "stop_charging": {
-        "name": "Stop charging"
-      },
       "fetch_energy": {
         "name": "Fetch energy data"
       }


### PR DESCRIPTION
Follow-up on discussion #86, where `svincent75-sudo` (BYD Atto 2, Australia) and `chris-hemmings` reported the **Stop charging** button (#168) failing with *"stop_charging not supported for this vehicle/region"*.

That error message is misleading — it's not region- or vehicle-specific. `BydClient.stop_charging()` in pyBYD **unconditionally raises `BydEndpointNotSupportedError` for every VIN, every region, no exceptions**:

```python
async def stop_charging(...) -> ChargeChangeResult:
    """Not supported: the BYD cloud has no working stop-charge command.
    ...verified no-op... changeResult returns res: 2 "Operation successful"
    but the vehicle keeps charging...
    """
    raise BydEndpointNotSupportedError(...)
```

This was intentional — found and documented back in `jkaberg/pyBYD#59`, after a live test confirmed `/control/smartCharge/changeChargeStatue status="0"` always reports success while the car keeps charging. But then #168 went and put a button in front of a call that's guaranteed to fail for 100% of users, which is worse than not having the button: it reads as broken/buggy rather than "not implemented", and on some vehicles surfaces a per-VIN-sounding error that isn't per-VIN at all. My mistake for not connecting those two dots when I opened #168 — sorry for the noise.

This PR removes the button, the now-dead `coordinator.async_stop_charging`, and the orphaned `stop_charging` translation strings. No user-facing workaround is lost — #86 already has two that genuinely work: shrinking the smart-charging schedule window (via the existing `save_charging_schedule` service) or the key-fob/door-handle double-unlock.

Separately replying on #86 to close the loop with the reporters and correct my own answer in #166 (where I described this button as working, which was wrong).