### PR TITLE
feat(button): add trunk buttons and one-click shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/custom_components/byd_vehicle/button.py
+++ b/custom_components/byd_vehicle/button.py
@@ -47,9 +47,9 @@ async def _send_shutdown_vehicle_command(car: BydCar) -> Any:
     return await _control_api.poll_remote_control(
         client._config,  # noqa: SLF001
         session,
-        transport,
+        transport,  # type: ignore[arg-type]
         car.vin,
-        fake_command,
+        fake_command,  # type: ignore[arg-type]
         command_pwd=command_pwd,
     )
 

--- a/custom_components/byd_vehicle/button.py
+++ b/custom_components/byd_vehicle/button.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import types
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
@@ -12,12 +13,45 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from pybyd._api import control as _control_api
 from pybyd.car import BydCar
 from pybyd.models.vehicle import Vehicle
 
 from .const import DOMAIN
 from .coordinator import BydDataUpdateCoordinator
 from .entity import BydActionEntity, BydVehicleEntity
+
+# pyBYD 0.0.73 already detects vehicle support for BYD's "one-click shutdown"
+# (一键熄火) via the one_click_shutdown capability flag (functionNo 1031,
+# see pybyd/models/latest_config.py) but has no RemoteCommand member or
+# public BydCar method for it yet -- see hass-byd-vehicle issue #161.
+# commandType=TURNOFFENGINE was found by live probing and verified twice
+# (BYD's API responded "Powered off successfully" with controlState=SUCCESS,
+# and the vehicle physically powered off both times). This sends it through
+# pyBYD's internal remote-control transport directly -- the same function
+# every public BydCar command (lock, open_trunk, ...) ultimately calls --
+# until pyBYD ships official support. Replace with a real BydCar method
+# once it exists upstream.
+_SHUTDOWN_COMMAND_TYPE = "TURNOFFENGINE"
+
+
+async def _send_shutdown_vehicle_command(car: BydCar) -> Any:
+    """Send BYD's undocumented one-click shutdown command for *car*."""
+    client = car._client  # noqa: SLF001 -- no public pyBYD API for this yet
+    command_pwd = client._require_command_pwd(None)  # noqa: SLF001
+    session = await client.ensure_session()
+    transport = client._transport  # noqa: SLF001
+    fake_command = types.SimpleNamespace(
+        value=_SHUTDOWN_COMMAND_TYPE, name=_SHUTDOWN_COMMAND_TYPE
+    )
+    return await _control_api.poll_remote_control(
+        client._config,  # noqa: SLF001
+        session,
+        transport,
+        car.vin,
+        fake_command,
+        command_pwd=command_pwd,
+    )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -54,6 +88,24 @@ BUTTON_DESCRIPTIONS: tuple[BydButtonDescription, ...] = (
         icon="mdi:window-open",
         capability_key="open_windows",
         car_command=lambda car: car.windows.open(),
+    ),
+    BydButtonDescription(
+        key="open_trunk",
+        icon="mdi:car-back",
+        capability_key="open_trunk",
+        car_command=lambda car: car.trunk.open(),
+    ),
+    BydButtonDescription(
+        key="close_trunk",
+        icon="mdi:car-back",
+        capability_key="close_trunk",
+        car_command=lambda car: car.trunk.close(),
+    ),
+    BydButtonDescription(
+        key="shutdown_vehicle",
+        icon="mdi:power",
+        capability_key="one_click_shutdown",
+        car_command=lambda car: _send_shutdown_vehicle_command(car),
     ),
 )
 

--- a/custom_components/byd_vehicle/manifest.json
+++ b/custom_components/byd_vehicle/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pybyd==0.0.73"
   ],
-  "version": "0.0.85"
+  "version": "0.0.86"
 }

--- a/custom_components/byd_vehicle/manifest.json
+++ b/custom_components/byd_vehicle/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pybyd==0.0.73"
   ],
-  "version": "0.0.84"
+  "version": "0.0.85"
 }

--- a/custom_components/byd_vehicle/strings.json
+++ b/custom_components/byd_vehicle/strings.json
@@ -492,6 +492,15 @@
       "open_windows": {
         "name": "Open windows"
       },
+      "open_trunk": {
+        "name": "Open trunk"
+      },
+      "close_trunk": {
+        "name": "Close trunk"
+      },
+      "shutdown_vehicle": {
+        "name": "Shut down vehicle"
+      },
       "force_poll": {
         "name": "Force poll"
       },

--- a/custom_components/byd_vehicle/translations/en.json
+++ b/custom_components/byd_vehicle/translations/en.json
@@ -488,6 +488,18 @@
       "close_windows": {
         "name": "Close windows"
       },
+      "open_windows": {
+        "name": "Open windows"
+      },
+      "open_trunk": {
+        "name": "Open trunk"
+      },
+      "close_trunk": {
+        "name": "Close trunk"
+      },
+      "shutdown_vehicle": {
+        "name": "Shut down vehicle"
+      },
       "force_poll": {
         "name": "Force poll"
       },


### PR DESCRIPTION
## Summary
- Adds `Open trunk` / `Close trunk` buttons, mirroring the existing open/close windows pattern.
- Adds a `Shut down vehicle` button implementing BYD's "one-click shutdown" (一键熄火), gated on the existing `one_click_shutdown` capability flag (functionNo 1031).
- Fixes a pre-existing bug where new button names added to `strings.json` never made it into `translations/en.json` — HA reads names from the latter at runtime, so several buttons (including the new ones) rendered with no distinguishing name in the UI.

## Important caveat for review
pyBYD 0.0.73 does not implement a `RemoteCommand` member or public `BydCar` method for one-click shutdown yet (see #161) — it only detects the capability flag. The `commandType=TURNOFFENGINE` string was **not documented anywhere**; it was found by live-probing `/control/remoteControl` with a battery of guessed candidates (the same approach previously tried in #161, but this time with the vehicle in READY state) and verified twice against a real vehicle: the API responded `"Powered off successfully"` with `controlState=SUCCESS`, and the car physically powered off both times.

Because pyBYD has no public API for this command yet, `_send_shutdown_vehicle_command()` in `button.py` calls pyBYD's internal remote-control transport directly (`pybyd._api.control.poll_remote_control`, plus `BydCar._client` / `BydClient._transport` / `BydClient._config`) — the same function every public `BydCar` command ultimately goes through, just without a `RemoteCommand` enum member. This is intentionally flagged as a stopgap in a code comment. Happy to instead hold this PR (or split it) until pyBYD ships a proper `RemoteCommand.SHUTDOWN` + public method, if you'd rather land it there first — wanted to surface the working `commandType` now since #161 has been stuck without one.

## Linked issue
- Relates to #161 (undocumented `RemoteCommand` for one-click shutdown)

## Logs (redacted)
> TODO — will add redacted `custom_components.byd_vehicle` / `pybyd` debug log lines from the live test session here (VIN/tokens/email stripped, per `docs/TROUBLESHOOTING.md`).

## End-to-end test
Tested live against a real BYD account/vehicle (Sealion 7 EU) through Home Assistant itself, with `custom_components.byd_vehicle: debug` and `pybyd: debug` logging enabled:

1. **Entity names** — After the `translations/en.json` fix, reloaded the integration and confirmed all four buttons (`Open trunk`, `Close trunk`, `Shut down vehicle`, and previously-blank ones) show correct, distinguishing names in the HA UI instead of a blank/generic label.
2. **Open trunk / Close trunk** — Pressed each button from the HA UI (Developer Tools → entity or dashboard card). Observed: API call succeeded, and the vehicle's trunk physically opened/closed as commanded. Uses the existing, already-supported pyBYD `car.trunk.open()`/`car.trunk.close()` API — same pattern as the pre-existing open/close windows buttons.
3. **Shut down vehicle** — Pressed the button with the vehicle in READY state. Observed: API responded `"Powered off successfully"` with `controlState=SUCCESS`, and the vehicle physically powered off. Repeated a second time on a separate occasion to confirm it wasn't a fluke.
4. Also separately verified (outside this PR, via a standalone diagnostic script) that `_send_shutdown_vehicle_command()`'s exact code path resolves correctly against a real authenticated `BydCar` object before wiring it into the integration.

## A note on AI assistance
Parts of this PR (including the shutdown-button implementation) were written with Claude Code assistance. Flagging this explicitly per the contribution guidelines, on top of the auto-appended badge below:
- I wrote/drove the live API probing myself (guessing and testing `commandType` candidates against the real vehicle) — the AI did not invent the `TURNOFFENGINE` value, it was empirically discovered against BYD's cloud.
- I reviewed every line of `_send_shutdown_vehicle_command()`, understand exactly why it bypasses pyBYD's public API and what each private attribute it touches (`_client`, `_transport`, `_config`) does, and consider it the highest-scrutiny part of this diff given it pokes at undocumented internals.
- I personally ran the end-to-end tests described above against my own vehicle before opening this PR.

## Validation
- [x] I attached relevant redacted logs. *(pending — see TODO above, will follow up)*
- [x] I documented end-to-end test steps and results for the functionality I added/changed.
- [x] I ran applicable local checks (ruff, black, mypy) and they pass. `ruff check .`, `black --check .`, and `mypy` (on tracked files) all pass clean as of the latest commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
