### PR TITLE
feat(button): add open_trunk and close_trunk buttons

### DIFF
--- a/custom_components/byd_vehicle/button.py
+++ b/custom_components/byd_vehicle/button.py
@@ -55,6 +55,18 @@ BUTTON_DESCRIPTIONS: tuple[BydButtonDescription, ...] = (
         capability_key="open_windows",
         car_command=lambda car: car.windows.open(),
     ),
+    BydButtonDescription(
+        key="open_trunk",
+        icon="mdi:car-back",
+        capability_key="open_trunk",
+        car_command=lambda car: car.trunk.open(),
+    ),
+    BydButtonDescription(
+        key="close_trunk",
+        icon="mdi:car-back",
+        capability_key="close_trunk",
+        car_command=lambda car: car.trunk.close(),
+    ),
 )
 
 

--- a/custom_components/byd_vehicle/translations/en.json
+++ b/custom_components/byd_vehicle/translations/en.json
@@ -488,6 +488,12 @@
       "close_windows": {
         "name": "Close windows"
       },
+      "open_trunk": {
+        "name": "Open trunk"
+      },
+      "close_trunk": {
+        "name": "Close trunk"
+      },
       "force_poll": {
         "name": "Force poll"
       },


### PR DESCRIPTION
Wires up TrunkCapability (already present in pyBYD) as HA button entities, following the existing close_windows/open_windows pattern. Gated by capability_key so it only appears on vehicles whose function_nos include the corresponding command (1020/1021).

Tested against a BYD Sealion 8 (AU region): open_trunk successfully opens the boot. close_trunk does not appear for this VIN since 1021 isn't registered in its capability profile — confirmed this is a genuine vehicle-level limitation, not a mapping gap, since the official BYD app also cannot remotely close the boot on this car.

Separately noticed while testing: the existing trunk_lid binary sensor in binary_sensor.py is disabled by default. Might be worth enabling it by default alongside this, since it pairs naturally with the open button.

## Summary
- Adds `open_trunk` and `close_trunk` BydButtonDescription entries to BUTTON_DESCRIPTIONS, calling car.trunk.open()/close() (existing pyBYD TrunkCapability).
- Adds matching translation strings in en.json.
- No changes to existing entities or behavior.

## Linked issue
- N/A — no tracked issue for this specific gap.

## Logs (required, redacted)
- No raw debug logs captured for this session. Verification was via direct observation: pressed button.garage_byd_sealion_8_open_trunk in Home Assistant and confirmed the physical boot opened on the vehicle. close_trunk did not appear as an entity at all, consistent with the capability gate correctly excluding it for this VIN (1021 not present in the vehicle's function_nos).

## End-to-end test (required for new/changed functionality)
- Applied this change locally to a running Home Assistant instance with the BYD Vehicle integration configured for a Sealion 8 (AU region).
- Restarted HA. Confirmed `button.garage_byd_sealion_8_open_trunk` appeared as a new entity; the equivalent close_trunk entity did not appear (expected, per capability gating).
- Pressed the open_trunk button from the HA entity dialog. Observed the vehicle's boot physically open within a few seconds.
- No errors in the entity or elsewhere in the UI.

## Validation
- [ ] I attached relevant redacted logs. *(see Logs section above — no raw logs; direct physical verification instead)*
- [x] I documented end-to-end test steps and results for the functionality I added/changed.
- [x] I ran applicable local checks (ruff, black) — both pass cleanly. mypy not run (requires full HA install to resolve imports; change mirrors existing, already-typed open_windows/close_windows entries exactly).