### PR TITLE
fix: preserve previous cabin temperature on stale telemetry

### DIFF
--- a/custom_components/byd_vehicle/sensor.py
+++ b/custom_components/byd_vehicle/sensor.py
@@ -391,6 +391,7 @@ SENSOR_DESCRIPTIONS: tuple[BydSensorDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=_round_int_attr("temp_in_car"),
+        validator_fn=keep_previous_when_zero,
     ),
     # Tire pressures – unit resolved dynamically from tire_press_unit;
     # kPa is the default because most BYD vehicles report tirePressUnit=3.
@@ -446,6 +447,7 @@ SENSOR_DESCRIPTIONS: tuple[BydSensorDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=_round_int_attr("temp_out_car"),
+        validator_fn=keep_previous_when_zero,
     ),
     BydSensorDescription(
         key="pm",


### PR DESCRIPTION
## Summary

When the BYD API returns missing or zero temperature telemetry while the
vehicle is idle or parked, the cabin and exterior temperature sensors can
temporarily show `0` or `unknown`.

This change adds the existing `keep_previous_when_zero` validator to both
temperature sensors:

- `temp_in_car`
- `temp_out_car`

When the calculated value is `0` or `None`, the sensor keeps its previous
known-good value until fresh valid telemetry arrives.

## Linked issue

No linked issue.

## Logs

Relevant Home Assistant state/history was checked directly. No sensitive
values are included here; vehicle identifiers and account details have been
omitted.

The system log did show intermittent BYD cloud/API connectivity errors during
the review period (DNS timeout, MQTT connection resets, and HTTP 503). These
are relevant because the change is intended to prevent stale or missing
telemetry from overwriting the last known temperature, but the logs do not
contain a captured `0`/`None` temperature event.

## End-to-end test

Home Assistant verification was performed against the live BYD integration:

- Both target entities exist and are available:
  - `sensor.byd_seal_u_cabin_temperature`
  - `sensor.byd_seal_u_exterior_temperature`
- Seven days of Home Assistant history were reviewed (`2026-08-21` through
`2026-08-28`):
  - Cabin temperature: 182 recorded states, 0 values of `0`, 0 `unknown`,
    and 0 `unavailable`.
  - Exterior temperature: 37 recorded states, 0 values of `0`, 0 `unknown`,
    and 0 `unavailable`.

This confirms that both sensors remain available and report valid values
through normal polling, including while the integration experienced some
upstream connectivity failures. A telemetry response containing an explicit
zero or missing temperature was not captured during this verification window,
so the specific keep-previous branch was not directly exercised end-to-end.

## Validation

- [x] `python3 -m compileall -q custom_components`
- [x] `ruff check custom_components/byd_vehicle/sensor.py`
- [x] `git diff --check`
- [x] Live Home Assistant entity/state verification completed.
- [x] Seven days of Home Assistant history checked for `0`, `unknown`, and
  `unavailable` temperature states.